### PR TITLE
fix: `/mwm update-day` をコンソール専用に変更

### DIFF
--- a/src/main/kotlin/me/awabi2048/myworldmanager/command/WorldCommand.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/command/WorldCommand.kt
@@ -91,8 +91,8 @@ class WorldCommand(
             }
             "update-day" -> {
                 val lang = plugin.languageManager
-                if (!PermissionManager.checkPermission(sender, PermissionManager.ADMIN)) {
-                    PermissionManager.sendNoPermissionMessage(sender)
+                if (sender !is org.bukkit.command.ConsoleCommandSender) {
+                    sender.sendMessage(lang.getMessage("messages.console_only"))
                     return true
                 }
                 plugin.worldService.updateDailyData()
@@ -277,8 +277,9 @@ class WorldCommand(
 
         when (args.size) {
             1 -> {
-                list.addAll(listOf("create", "reload", "update-day", "stats", "give"))
+                list.addAll(listOf("create", "reload", "stats", "give"))
                 if (sender is org.bukkit.command.ConsoleCommandSender) {
+                    list.add("update-day")
                     list.addAll(listOf("migrate-worlds", "migrate-players", "migrate-portals"))
                 }
             }


### PR DESCRIPTION
Ref: #3

`/mwm update-day` コマンドをコンソール専用に変更しました。
また、プレイヤーのタブ補完候補から `update-day` を除外しました。