### PR TITLE
fix: 一部のメニューでクリック処理が行われていない問題を修正

### DIFF
--- a/src/main/kotlin/me/awabi2048/myworldmanager/listener/FavoriteListener.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/listener/FavoriteListener.kt
@@ -45,6 +45,9 @@ class FavoriteListener(private val plugin: MyWorldManager) : Listener {
             }
             
             if (type == ItemTag.TYPE_GUI_DECORATION || type == ItemTag.TYPE_GUI_INFO) return
+            
+            // ワールドアイテム処理
+            if (type != ItemTag.TYPE_GUI_WORLD_ITEM) return
 
             val uuid = ItemTag.getWorldUuid(currentItem) ?: return
             val worldData = plugin.worldConfigRepository.findByUuid(uuid) ?: return

--- a/src/main/kotlin/me/awabi2048/myworldmanager/listener/VisitListener.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/listener/VisitListener.kt
@@ -24,81 +24,84 @@ class VisitListener(private val plugin: MyWorldManager) : Listener {
         if (lang.isKeyMatch(title, "gui.visit.title")) {
             event.isCancelled = true
             val currentItem = event.currentItem ?: return
-            val type = ItemTag.getType(currentItem)
+            val type = ItemTag.getType(currentItem) ?: return
             if (currentItem.type == Material.AIR || type == ItemTag.TYPE_GUI_DECORATION) return
 
-            val uuid = ItemTag.getWorldUuid(currentItem) ?: return
-
-            if (type == ItemTag.TYPE_GUI_RETURN) {
-                plugin.soundManager.playClickSound(player, currentItem)
-                val worldData = plugin.worldConfigRepository.findByUuid(uuid)
-                if (worldData != null) {
-                    plugin.favoriteMenuGui.open(player, worldData)
-                }
-                return
-            }
-
-            if (event.isLeftClick) {
-                val worldData = plugin.worldConfigRepository.findByUuid(uuid)
-                val isMember = worldData != null && (worldData.owner == player.uniqueId || 
-                              worldData.moderators.contains(player.uniqueId) ||
-                              worldData.members.contains(player.uniqueId))
-
-                if (worldData == null || (worldData.publishLevel != PublishLevel.PUBLIC && !isMember)) {
-                    player.sendMessage(lang.getMessage(player, "messages.world_not_public"))
-                    plugin.soundManager.playActionSound(player, "visit", "access_denied")
-                    player.closeInventory()
-                    return
-                }
-
-                plugin.soundManager.playClickSound(player, currentItem)
-                plugin.worldService.teleportToWorld(player, uuid)
-                player.sendMessage(lang.getMessage(player, "messages.warp_success", mapOf("world" to worldData.name)))
-                plugin.worldService.sendAnnouncementMessage(player, worldData)
-                
-                if (!isMember) {
-                    worldData.recentVisitors[0]++
-                    plugin.worldConfigRepository.save(worldData)
-                }
-                
-                player.closeInventory()
-            } else if (event.isRightClick) {
-                // お気に入り処理
-                val stats = plugin.playerStatsRepository.findByUuid(player.uniqueId)
-                val worldData = plugin.worldConfigRepository.findByUuid(uuid) ?: return
-
-                if (stats.favoriteWorlds.containsKey(uuid)) {
-                    stats.favoriteWorlds.remove(uuid)
-                    worldData.favorite = (worldData.favorite - 1).coerceAtLeast(0)
-                    
-                    plugin.playerStatsRepository.save(stats)
-                    plugin.worldConfigRepository.save(worldData)
-                    player.sendMessage(lang.getMessage(player, "messages.favorite_removed"))
-                    plugin.soundManager.playActionSound(player, "visit", "favorite_remove")
-                } else {
-                    if (worldData.owner == player.uniqueId || worldData.moderators.contains(player.uniqueId) || worldData.members.contains(player.uniqueId)) {
-                        return
+            when (type) {
+                ItemTag.TYPE_GUI_RETURN -> {
+                    val uuid = ItemTag.getWorldUuid(currentItem) ?: return
+                    plugin.soundManager.playClickSound(player, currentItem)
+                    val worldData = plugin.worldConfigRepository.findByUuid(uuid)
+                    if (worldData != null) {
+                        plugin.favoriteMenuGui.open(player, worldData)
                     }
-                    val maxFav = plugin.config.getInt("favorite.max_count", 1000)
-                    if (stats.favoriteWorlds.size >= maxFav) {
-                        player.sendMessage(lang.getMessage(player, "messages.favorite_limit_reached", mapOf("max" to maxFav)))
-                        return
-                    }
-
-                    val today = java.time.LocalDate.now().toString()
-                    stats.favoriteWorlds[uuid] = today
-                    worldData.favorite++
-                    
-                    plugin.playerStatsRepository.save(stats)
-                    plugin.worldConfigRepository.save(worldData)
-                    player.sendMessage(lang.getMessage(player, "messages.favorite_added"))
-                    plugin.soundManager.playActionSound(player, "visit", "favorite_add")
                 }
-                
-                // 表示更新
-                val targetPlayerName = title.substringBefore(lang.getMessage(player, "gui.visit.title").replace("{0}", ""))
-                val targetPlayer = Bukkit.getOfflinePlayer(targetPlayerName)
-                VisitGui(plugin).open(player, targetPlayer)
+                ItemTag.TYPE_GUI_WORLD_ITEM -> {
+                    val uuid = ItemTag.getWorldUuid(currentItem) ?: return
+
+                    if (event.isLeftClick) {
+                        val worldData = plugin.worldConfigRepository.findByUuid(uuid)
+                        val isMember = worldData != null && (worldData.owner == player.uniqueId || 
+                                      worldData.moderators.contains(player.uniqueId) ||
+                                      worldData.members.contains(player.uniqueId))
+
+                        if (worldData == null || (worldData.publishLevel != PublishLevel.PUBLIC && !isMember)) {
+                            player.sendMessage(lang.getMessage(player, "messages.world_not_public"))
+                            plugin.soundManager.playActionSound(player, "visit", "access_denied")
+                            player.closeInventory()
+                            return
+                        }
+
+                        plugin.soundManager.playClickSound(player, currentItem)
+                        plugin.worldService.teleportToWorld(player, uuid)
+                        player.sendMessage(lang.getMessage(player, "messages.warp_success", mapOf("world" to worldData.name)))
+                        plugin.worldService.sendAnnouncementMessage(player, worldData)
+                        
+                        if (!isMember) {
+                            worldData.recentVisitors[0]++
+                            plugin.worldConfigRepository.save(worldData)
+                        }
+                        
+                        player.closeInventory()
+                    } else if (event.isRightClick) {
+                        // お気に入り処理
+                        val stats = plugin.playerStatsRepository.findByUuid(player.uniqueId)
+                        val worldData = plugin.worldConfigRepository.findByUuid(uuid) ?: return
+
+                        if (stats.favoriteWorlds.containsKey(uuid)) {
+                            stats.favoriteWorlds.remove(uuid)
+                            worldData.favorite = (worldData.favorite - 1).coerceAtLeast(0)
+                            
+                            plugin.playerStatsRepository.save(stats)
+                            plugin.worldConfigRepository.save(worldData)
+                            player.sendMessage(lang.getMessage(player, "messages.favorite_removed"))
+                            plugin.soundManager.playActionSound(player, "visit", "favorite_remove")
+                        } else {
+                            if (worldData.owner == player.uniqueId || worldData.moderators.contains(player.uniqueId) || worldData.members.contains(player.uniqueId)) {
+                                return
+                            }
+                            val maxFav = plugin.config.getInt("favorite.max_count", 1000)
+                            if (stats.favoriteWorlds.size >= maxFav) {
+                                player.sendMessage(lang.getMessage(player, "messages.favorite_limit_reached", mapOf("max" to maxFav)))
+                                return
+                            }
+
+                            val today = java.time.LocalDate.now().toString()
+                            stats.favoriteWorlds[uuid] = today
+                            worldData.favorite++
+                            
+                            plugin.playerStatsRepository.save(stats)
+                            plugin.worldConfigRepository.save(worldData)
+                            player.sendMessage(lang.getMessage(player, "messages.favorite_added"))
+                            plugin.soundManager.playActionSound(player, "visit", "favorite_add")
+                        }
+                        
+                        // 表示更新
+                        val targetPlayerName = title.substringBefore(lang.getMessage(player, "gui.visit.title").replace("{player}", ""))
+                        val targetPlayer = Bukkit.getOfflinePlayer(targetPlayerName)
+                        VisitGui(plugin).open(player, targetPlayer)
+                    }
+                }
             }
             return
         }


### PR DESCRIPTION
## 概要
Issue #34 に対応。

## 変更内容
- `VisitListener.kt`: タグがnullの場合の早期リターンを追加し、`TYPE_GUI_WORLD_ITEM`の明示的なチェックを追加
- `FavoriteListener.kt`: ワールドアイテム処理前に`TYPE_GUI_WORLD_ITEM`の明示的なチェックを追加

## 修正対象
- `/visit`メニュー
- お気に入りメニュー内「このプレイヤーのほかのワールド」

Closes #34