### PR TITLE
fix: add separator to world icon lore (issue #17)

### DIFF
--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/DiscoveryGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/DiscoveryGui.kt
@@ -142,6 +142,7 @@ class DiscoveryGui(private val plugin: MyWorldManager) {
         lore.add(lang.getComponent(player, "gui.discovery.world_item.warp").decoration(TextDecoration.ITALIC, false))
         lore.add(lang.getComponent(player, "gui.discovery.world_item.preview").decoration(TextDecoration.ITALIC, false))
         lore.add(lang.getComponent(player, "gui.discovery.world_item.favorite_toggle").decoration(TextDecoration.ITALIC, false))
+        lore.add(lang.getComponent(player, "gui.common.separator").decoration(TextDecoration.ITALIC, false))
 
         meta.lore(lore)
         item.itemMeta = meta

--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/FavoriteGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/FavoriteGui.kt
@@ -152,6 +152,7 @@ class FavoriteGui(private val plugin: MyWorldManager) {
             lore.add(lang.getComponent(player, "gui.favorite.world_item.unfavorite"))
             lore.add(lang.getComponent(player, "gui.common.separator"))
         }
+        lore.add(lang.getComponent(player, "gui.common.separator"))
         
         meta.lore(lore)
         item.itemMeta = meta

--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/PlayerWorldGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/PlayerWorldGui.kt
@@ -170,6 +170,7 @@ class PlayerWorldGui(private val plugin: MyWorldManager) {
             lore.add(lang.getComponent(player, "gui.player_world.world_item.expired"))
             lore.add(lang.getComponent(player, "gui.common.separator"))
         }
+        lore.add(lang.getComponent(player, "gui.common.separator"))
 
         meta.lore(lore)
         item.itemMeta = meta

--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/VisitGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/VisitGui.kt
@@ -132,6 +132,7 @@ class VisitGui(private val plugin: MyWorldManager) {
             }
             lore.add(lang.getComponent(viewer, "gui.common.separator"))
         }
+        lore.add(lang.getComponent(viewer, "gui.common.separator"))
         
         meta.lore(lore)
         item.itemMeta = meta


### PR DESCRIPTION
マイワールドアイコンのLoreの最終行にセパレータを追加しました。 (Issue #17)