### PR TITLE
Fix: Issue #26 プレイヤーフィルターLoreのレイアウト変更 (Git復旧対応済み)

### DIFF
--- a/src/main/kotlin/me/awabi2048/myworldmanager/MyWorldManager.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/MyWorldManager.kt
@@ -1,1 +1,259 @@
+package me.awabi2048.myworldmanager
+
+import me.awabi2048.myworldmanager.command.*
+import me.awabi2048.myworldmanager.gui.*
+import me.awabi2048.myworldmanager.listener.*
+import me.awabi2048.myworldmanager.model.WorldData
+import me.awabi2048.myworldmanager.repository.*
+import me.awabi2048.myworldmanager.service.*
+import me.awabi2048.myworldmanager.session.*
+import me.awabi2048.myworldmanager.util.*
+import org.bukkit.configuration.serialization.ConfigurationSerialization
+import org.bukkit.entity.Player
+import org.bukkit.plugin.java.JavaPlugin
+
+class MyWorldManager : JavaPlugin() {
+ 
+    lateinit var worldConfigRepository: WorldConfigRepository
+    lateinit var worldService: WorldService
+    lateinit var worldGui: WorldGui
+    lateinit var creationSessionManager: CreationSessionManager
+    lateinit var templateRepository: TemplateRepository
+    lateinit var playerStatsRepository: PlayerStatsRepository
+    lateinit var spotlightRepository: SpotlightRepository
+    
+    lateinit var settingsSessionManager: SettingsSessionManager
+    lateinit var inviteSessionManager: InviteSessionManager
+    lateinit var worldSettingsGui: WorldSettingsGui
+    lateinit var worldValidator: WorldValidator
+    lateinit var portalRepository: PortalRepository
+    lateinit var portalManager: PortalManager
+    lateinit var memberInviteManager: MemberInviteManager
+    lateinit var discoverySessionManager: DiscoverySessionManager
+    lateinit var soundManager: SoundManager
+    lateinit var menuConfigManager: MenuConfigManager
+    
+    lateinit var creationGui: CreationGui
+    lateinit var discoveryGui: DiscoveryGui
+    lateinit var favoriteGui: FavoriteGui
+    lateinit var favoriteMenuGui: FavoriteMenuGui
+    lateinit var favoriteConfirmGui: FavoriteConfirmGui
+    lateinit var meetGui: MeetGui
+    lateinit var playerWorldGui: PlayerWorldGui
+    lateinit var userSettingsGui: UserSettingsGui
+    lateinit var adminPortalGui: AdminPortalGui
+    lateinit var templateWizardGui: TemplateWizardGui
+    lateinit var adminCommandGui: AdminCommandGui
+    lateinit var spotlightConfirmGui: SpotlightConfirmGui
+    lateinit var environmentGui: EnvironmentGui
+    lateinit var environmentConfirmGui: EnvironmentConfirmGui
+    lateinit var worldSeedConfirmGui: WorldSeedConfirmGui
+    lateinit var languageManager: LanguageManager
+    lateinit var previewSessionManager: PreviewSessionManager
+    lateinit var adminGuiSessionManager: AdminGuiSessionManager
+    lateinit var macroManager: MacroManager
+    lateinit var directoryManager: DirectoryManager
+    lateinit var worldUnloadService: WorldUnloadService
+
+    override fun onEnable() {
+        // Serializationの登録
+        ConfigurationSerialization.registerClass(WorldData::class.java)
+
+        // 設定用フォルダの作成
+        if (!dataFolder.exists()) {
+            dataFolder.mkdirs()
+        }
+        saveDefaultConfig()
+        
+        // langフォルダが存在しなければ作成し、デフォルトの言語ファイルをコピー
+        val langFolder = java.io.File(dataFolder, "lang")
+        if (!langFolder.exists()) {
+            langFolder.mkdirs()
+        }
+        saveResourceIfNotExists("lang/ja_jp.yml")
+        saveResourceIfNotExists("lang/en_us.yml")
+        
+        // templates.ymlがなければコピー
+        saveResourceIfNotExists("templates.yml")
+        
+        // 言語設定の初期化
+        languageManager = LanguageManager(this)
+ 
+        // リポジトリの初期化
+        worldConfigRepository = WorldConfigRepository(this)
+        templateRepository = TemplateRepository(this)
+        
+        directoryManager = DirectoryManager(this, worldConfigRepository, templateRepository)
+        // ワールド・テンプレートディレクトリの存在チェック
+        directoryManager.checkDirectories()
+        
+        playerStatsRepository = PlayerStatsRepository(this)
+        portalRepository = PortalRepository(this)
+        spotlightRepository = SpotlightRepository(this)
+        
+        // サービスの初期化
+        worldService = WorldService(this, worldConfigRepository, playerStatsRepository)
+        portalManager = PortalManager(this)
+        portalManager.startTasks()
+        worldUnloadService = WorldUnloadService(this)
+        worldUnloadService.start()
+        
+        // GUIの初期化
+        worldGui = WorldGui(this)
+        creationGui = CreationGui(this)
+        discoveryGui = DiscoveryGui(this)
+        favoriteGui = FavoriteGui(this)
+        favoriteMenuGui = FavoriteMenuGui(this)
+        favoriteConfirmGui = FavoriteConfirmGui(this)
+        meetGui = MeetGui(this)
+        playerWorldGui = PlayerWorldGui(this)
+        worldSettingsGui = WorldSettingsGui(this)
+        userSettingsGui = UserSettingsGui(this)
+        adminPortalGui = AdminPortalGui(this)
+        adminCommandGui = AdminCommandGui(this)
+        templateWizardGui = TemplateWizardGui(this)
+        spotlightConfirmGui = SpotlightConfirmGui(this)
+        environmentGui = EnvironmentGui(this)
+        environmentConfirmGui = EnvironmentConfirmGui(this)
+        worldSeedConfirmGui = WorldSeedConfirmGui(this)
+        
+        creationSessionManager = CreationSessionManager(this)
+        inviteSessionManager = InviteSessionManager()
+        macroManager = MacroManager(this)
+        // MemberInviteManagerの初期化に依存関係を渡す
+        memberInviteManager = MemberInviteManager(this, worldConfigRepository, macroManager)
+        
+        // 設定機能の初期化
+        settingsSessionManager = SettingsSessionManager()
+        discoverySessionManager = DiscoverySessionManager()
+        worldValidator = WorldValidator(this)
+        soundManager = SoundManager(this)
+        
+        // メニュー設定ファイルの初期化
+        val menusFolder = java.io.`File`(dataFolder, "menus")
+        if (!menusFolder.exists()) {
+            menusFolder.mkdirs()
+        }
+        listOf("player_world", "creation", "world_settings", "visit", "favorite", "discovery", "portal", "admin_manage").forEach { menuId ->
+            saveResourceIfNotExists("menus/$menuId.yml")
+        }
+        menuConfigManager = MenuConfigManager(this)
+        menuConfigManager.initialize()
+        
+        previewSessionManager = PreviewSessionManager(this)
+        adminGuiSessionManager = AdminGuiSessionManager()
+ 
+        val inviteCmd = InviteCommand(this)
+ 
+        // リスナーの登録
         server.pluginManager.registerEvents(AccessControlListener(this), this)
+        server.pluginManager.registerEvents(SpawnListener(worldConfigRepository), this)
+        // 旧 GuiListener を分割して登録
+        server.pluginManager.registerEvents(PlayerWorldListener(this), this)
+        server.pluginManager.registerEvents(VisitListener(this), this)
+        server.pluginManager.registerEvents(FavoriteListener(this), this)
+        server.pluginManager.registerEvents(MeetListener(this), this)
+        
+        server.pluginManager.registerEvents(AdminGuiListener(), this)
+        server.pluginManager.registerEvents(AdminCommandListener(), this)
+        server.pluginManager.registerEvents(CreationGuiListener(this), this)
+        server.pluginManager.registerEvents(CreationChatListener(this), this)
+        server.pluginManager.registerEvents(PlayerDataListener(), this)
+        server.pluginManager.registerEvents(WorldSettingsListener(), this)
+        server.pluginManager.registerEvents(WorldExpirationListener(worldConfigRepository), this)
+        server.pluginManager.registerEvents(InviteChatListener(this, inviteCmd), this)
+        server.pluginManager.registerEvents(PortalListener(this), this)
+        server.pluginManager.registerEvents(PortalGui(this), this)
+        server.pluginManager.registerEvents(DiscoveryListener(this), this)
+        server.pluginManager.registerEvents(SpotlightListener(this), this)
+        server.pluginManager.registerEvents(TemplatePreviewListener(), this)
+        server.pluginManager.registerEvents(EnvironmentLogicListener(this), this)
+        server.pluginManager.registerEvents(CustomItemListener(this), this)
+        server.pluginManager.registerEvents(WorldSeedListener(this), this)
+        server.pluginManager.registerEvents(WizardLunaChatListener(this), this)
+        server.pluginManager.registerEvents(TemplateWizardListener(), this)
+        server.pluginManager.registerEvents(TemplateWizardChatListener(this), this)
+        
+        // コマンドの登録
+        val mwmCmd = WorldCommand(worldService, creationSessionManager)
+        getCommand("mwm")?.setExecutor(mwmCmd)
+        getCommand("mwm")?.setTabCompleter(mwmCmd)
+        getCommand("myworld")?.setExecutor(PlayerWorldCommand(this))
+        getCommand("worldmenu")?.setExecutor(WorldMenuCommand(this))
+        getCommand("visit")?.let {
+            val visitCmd = VisitCommand(this)
+            it.setExecutor(visitCmd)
+            it.setTabCompleter(visitCmd)
+        }
+        
+        getCommand("invite")?.setExecutor(inviteCmd)
+        getCommand("invite")?.setTabCompleter(inviteCmd)
+        getCommand("inviteaccept_internal")?.setExecutor { sender, _, _, _ ->
+            if (sender is Player) inviteCmd.handleAccept(sender)
+            true
+        }
+        getCommand("memberinviteaccept_internal")?.setExecutor { sender, _, _, _ ->
+            if (sender is Player) memberInviteManager.handleMemberInviteAccept(sender)
+            true
+        }
+ 
+        getCommand("favorite")?.setExecutor(FavoriteCommand(this))
+        getCommand("discovery")?.setExecutor(DiscoveryCommand(this))
+        
+        val meetCmd = MeetCommand(this)
+        getCommand("meet")?.setExecutor(meetCmd)
+        getCommand("meet")?.setTabCompleter(meetCmd)
+
+        getCommand("settings")?.setExecutor(SettingsCommand(this))
+    }
+
+    override fun onDisable() {
+        if (::worldUnloadService.isInitialized) {
+            worldUnloadService.stop()
+        }
+    }
+
+    /**
+     * 設定ファイルとリポジトリのデータを再読み込みする（再起動と同等の処理）
+     */
+    fun reloadSystem() {
+        // デフォルト設定の保存（ファイルが存在しない場合のみ作成）
+        saveDefaultConfig()
+
+        // config.ymlの再読み込み
+        reloadConfig()
+        
+        // 各コンポーネントの再読み込み
+        languageManager.loadAllLanguages()
+        worldConfigRepository.loadAll()
+        templateRepository.loadTemplates()
+        portalRepository.loadAll()
+        spotlightRepository.load()
+        macroManager.loadConfig()
+        menuConfigManager.initialize() // フォルダ作成・デフォルトコピー・全読み込みを一括実行
+        
+        // ディレクトリの再チェック
+        directoryManager.checkDirectories()
+
+        // プレイヤーキャッシュのクリア（次回アクセス時に再読み込みされる）
+        playerStatsRepository.clearCache()
+        
+        // SoundManagerの設定再読み込み（config依存のためインスタンス再生成）
+        soundManager = SoundManager(this)
+        
+        // WorldUnloadServiceの再起動
+        worldUnloadService.start()
+        
+        logger.info("全てのシステム設定およびデータを再読み込みしました。")
+    }
+
+    /**
+     * リソースファイルが存在しない場合のみ保存する
+     */
+    private fun saveResourceIfNotExists(resourcePath: String) {
+        val file = java.io.File(dataFolder, resourcePath)
+        if (!file.exists()) {
+            saveResource(resourcePath, false)
+        }
+    }
+}

--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/WorldGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/WorldGui.kt
@@ -405,26 +405,30 @@ class WorldGui(private val plugin: MyWorldManager) {
         val item = ItemStack(Material.PLAYER_HEAD)
         val meta = item.itemMeta ?: return item
         val lang = plugin.languageManager
-        
+
         meta.displayName(lang.getComponent(player, "gui.admin.filter.player.display"))
-        
+
         val lore = mutableListOf<Component>()
+        val separator = lang.getComponent(null, "gui.common.separator")
         
+        lore.add(separator)
+
         // 現在の設定
         val filterTypeName = lang.getMessage(player, session.playerFilterType.displayKey)
         lore.add(lang.getComponent(player, "gui.admin.filter.player.current_type", mapOf("type" to filterTypeName)))
-        
-        if (session.playerFilter != null) {
+
+        if (session.playerFilterType != PlayerFilterType.NONE && session.playerFilter != null) {
             val targetName = Bukkit.getOfflinePlayer(session.playerFilter!!).name ?: "Unknown"
             lore.add(lang.getComponent(player, "gui.admin.filter.player.current_player", mapOf("player" to targetName)))
         }
-        
-        lore.add(Component.empty())
+
+        lore.add(separator)
         lore.add(lang.getComponent(player, "gui.admin.filter.player.click_left"))
         if (session.playerFilterType != PlayerFilterType.NONE) {
             lore.add(lang.getComponent(player, "gui.admin.filter.player.click_right"))
         }
-        
+        lore.add(separator)
+
         meta.lore(lore)
         item.itemMeta = meta
         ItemTag.tagItem(item, ItemTag.TYPE_GUI_ADMIN_FILTER_PLAYER)

--- a/src/main/kotlin/me/awabi2048/myworldmanager/listener/WorldSeedListener.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/listener/WorldSeedListener.kt
@@ -1,5 +1,79 @@
-                if (!consumed) {
-                    player.sendMessage(plugin.languageManager.getMessage(player, "messages.item_not_found_hand"))
+package me.awabi2048.myworldmanager.listener
+
+import me.awabi2048.myworldmanager.MyWorldManager
+import me.awabi2048.myworldmanager.util.ItemTag
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
+import org.bukkit.Sound
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.inventory.EquipmentSlot
+
+class WorldSeedListener(private val plugin: MyWorldManager) : Listener {
+
+    @EventHandler
+    fun onInventoryClick(event: InventoryClickEvent) {
+        val player = event.whoClicked as? Player ?: return
+        val view = event.view
+        
+        // Match Title using LanguageManager key matching
+        // Note: WorldSeedConfirmGui uses "gui.world_seed_confirm.title"
+        if (!plugin.languageManager.isKeyMatch(PlainTextComponentSerializer.plainText().serialize(view.title()), "gui.world_seed_confirm.title")) return
+        
+        event.isCancelled = true
+
+        val item = event.currentItem ?: return
+        val tag = ItemTag.getType(item) ?: return
+
+        when (tag) {
+            "world_seed_confirm_yes" -> {
+                // Execute Expansion
+                val stats = plugin.playerStatsRepository.findByUuid(player.uniqueId)
+                
+                // Double check limit just in case
+                val defaultSlots = plugin.config.getInt("creation.max_create_count_default")
+                val limit = plugin.config.getInt("creation.max_world_slots_limit", 10)
+                if (defaultSlots + stats.unlockedWorldSlot >= limit) {
+                    player.sendMessage(plugin.languageManager.getMessage(player, "messages.custom_item.world_seed_limit_reached", mapOf("limit" to limit)))
                     player.closeInventory()
                     return
                 }
+
+                // Consume Item
+                var consumed = false
+                val mainHand = player.inventory.itemInMainHand
+                val offHand = player.inventory.itemInOffHand
+
+                if (ItemTag.isType(mainHand, ItemTag.TYPE_WORLD_SEED)) {
+                    mainHand.amount -= 1
+                    consumed = true
+                } else if (ItemTag.isType(offHand, ItemTag.TYPE_WORLD_SEED)) {
+                    offHand.amount -= 1
+                    consumed = true
+                }
+
+                if (!consumed) {
+                    player.sendMessage("§cItem not found in hand.") // Should ideally use message key or be silent if weird state
+                    player.closeInventory()
+                    return
+                }
+
+                // Update Stats
+                stats.unlockedWorldSlot += 1
+                plugin.playerStatsRepository.save(stats)
+
+                // Message & Sound
+                val newTotal = defaultSlots + stats.unlockedWorldSlot
+                player.sendMessage(plugin.languageManager.getMessage(player, "messages.custom_item.world_seed_expanded", mapOf("slots" to newTotal)))
+                player.playSound(player.location, Sound.ENTITY_PLAYER_LEVELUP, 1.0f, 1.0f) // Or specific sound
+                
+                player.closeInventory()
+            }
+            "world_seed_confirm_no" -> {
+                plugin.soundManager.playClickSound(player, item)
+                player.closeInventory()
+            }
+        }
+    }
+}

--- a/src/main/resources/lang/en_us.yml
+++ b/src/main/resources/lang/en_us.yml
@@ -1,2 +1,1010 @@
-  unknown_world: "Unknown World"
-  item_not_found_hand: "§cItem not found in hand."
+# MyWorldManager Language File (English)
+
+# General
+general:
+  prefix: "§7[§aMyWorldManager§7] "
+  no_permission: "§cYou do not have permission."
+  player_only: "§cThis command can only be executed by a player."
+  world_not_found: "§cWorld not found."
+  player_not_found: "§cPlayer not found."
+  unknown: "Unknown"
+  direction:
+    north_west: "North West"
+    north_east: "North East"
+    south_west: "South West"
+    south_east: "South East"
+    unknown: "Unknown"
+    
+  commands:
+    settings:
+      description: "Opens the user settings menu."
+
+  language:
+    ja_jp: "日本語"
+    en_us: "English"
+
+# Publish Level
+publish_level:
+  public: "Public"
+  friend: "Limited"
+  private: "Private"
+  locked: "Locked"
+  description:
+    public: "§fAnyone can visit. Listed in the discovery menu."
+    friend: "§fAnyone can visit, but not listed in discovery menu."
+    private: "§fOnly invited players can visit."
+    locked: "§fNon-members cannot visit, and portal warp is disabled."
+  
+  color:
+    public: "§a"
+    friend: "§e"
+    private: "§c"
+    locked: "§c"
+    owner: "§6"
+    moderator: "§b"
+    member: "§f"
+    online: "§a"
+    offline: "§c"
+    active: "§a"
+    inactive: "§7"
+    uuid: "§8"
+    debug: "§8"
+
+# GUI Settings
+gui:
+  common:
+    back: "§7Back to Settings"
+    next_page: "§aNext Page"
+    prev_page: "§aPrev Page"
+    confirm: "§aExecute"
+    confirm_desc: "§7Click to execute"
+    cancel: "§cCancel"
+    cancel_desc: "§7Click to cancel"
+    separator: "§8§m-----------------------"
+    status_display: "§7Status: {color}{status}"
+    return: "§eBack"
+    return_desc: "§7Return to the previous menu"
+    world_item_name: "§f【§a{world}§f】"
+    world_item_name_simple: "§f「§a{world}§f」"
+    world_desc: "§f{description}"
+    confirmation: "Confirmation"
+    confirm_warning: "§cThis action involves important changes!"
+  
+  creation:
+    title_type: "Create World: Select Type"
+    title_template: "Create World: Select Template"
+    title_confirm: "Create World: Confirmation"
+    type:
+      template:
+        name: "From Template"
+        desc: "Create a world from a predefined template."
+      seed:
+        name: "Specify Seed"
+        desc: "Generate a world with a specific seed."
+      random:
+        name: "Random"
+        desc: "Generate a world with a random seed."
+      cost: "§f§l| §7Cost: §6🛖 §e{cost}"
+      points: "§f§l| §7Your Points: §6🛖 §e{points}"
+      available: "§aAvailable"
+      insufficient: "§cInsufficient points (§6🛖 §e{shortage} short)"
+    insufficient: "§cInsufficient points (§6🛖 §e{shortage} short)"
+    limit_reached: "§cYou have reached the limit of world creation. ({current}/{max})"
+    limit_reached_total: "§cThe server-wide limit for world creation ({limit}) has been reached."
+    template_item:
+      preview_hint: "§7Right-Click to Preview"
+    confirm:
+      name: "Confirm and Create"
+      world_name: "§f§l| §7World Name: §f{name}"
+      creation_type: "§f§l| §7Creation Type: §f{type}"
+      template: "§f§l| §7Template: §f{template}"
+      seed: "§f§l| §7Seed: §f{seed}"
+      cost: "§f§l| §7Cost: §6🛖 §e{cost}"
+
+  portal:
+    title: "Portal Settings"
+    id_format: "§8PORTAL_ID: {id}"
+    toggle_text:
+      name: "§aToggle Floating Text"
+      current: "§fCurrent Status: {status}"
+      click: "§eClick to Toggle"
+    destination_label: "§7Destination: "
+    color:
+      name: "§eParticle Color"
+      current: "§7Current: {color}"
+      click: "§eClick to change"
+      click_prev: "§7← Left-Click: {color}"
+      click_next: "§7Right-Click: {color} →"
+    remove:
+      name: "§cRemove Portal"
+      desc: "§7Removes the placed portal."
+      click: "§eClick to remove"
+    colors:
+      white: "White"
+      silver: "Silver"
+      gray: "Gray"
+      black: "Black"
+      red: "Red"
+      maroon: "Maroon"
+      yellow: "Yellow"
+      olive: "Olive"
+      lime: "Lime"
+      green: "Green"
+      aqua: "Aqua"
+      teal: "Teal"
+      blue: "Blue"
+      navy: "Navy"
+      fuchsia: "Magenta"
+      purple: "Purple"
+      orange: "Orange"
+
+  portal_item:
+    name: "§bWorld Portal"
+    lore_bind: "§e§l| §e§nRight-Click §fBind current MyWorld"
+    lore_unbind: "§e§l| §eShift+Right-Click §f§cUnbind§f world"
+    lore_dest: "§f§l| §bDestination §f§n{destination}"
+    lore_place: "§fRight-click to place a §dWorld Portal§f!"
+
+  template_wizard:
+    title: "Template Creation Wizard"
+    name_input:
+      display: "§eSet Template Name/ID"
+    desc_input:
+      display: "§eSet Template Description"
+    icon_select:
+      display: "§eSelect Template Icon"
+    origin_set:
+      display: "§eSet Origin Location"
+    save_confirm:
+      display: "§6Save and Register Template"
+
+  unarchive_confirm:
+    title: "§6Unarchive Confirmation"
+    lore:
+      - "§fThis world is currently archived."
+      - "§fDo you want to unarchive and warp?"
+  
+  settings:
+    title: "World Settings: {world}"
+    info:
+      display: "§aWorld Info Settings"
+      lore:
+        - "§e§l| §e§nLeft-Click §aChange Name"
+        - "§e§l| §e§nRight-Click §aChange Description"
+        - ""
+        - "§eType in chat to set"
+    spawn:
+      display: "§aSet Spawn Point"
+      type:
+        guest: "Guest"
+        member: "Member"
+      lore:
+        - "§7Left-Click: Set Guest Spawn"
+        - "§7Right-Click: Set Member Spawn"
+        - ""
+        - "§eClick a block after selection"
+        - "§eto set the location and direction."
+    icon:
+      display: "§aChange World Icon"
+      lore:
+        - "§7Click to enter change mode."
+        - "§7Then, click an item in your inventory"
+        - "§7to set it as the icon."
+    tags:
+      display: "§aWorld Tag Settings"
+      lore_header: "§f§l| §7Active Tags"
+      lore_empty: "  §fNone"
+      lore_item: "  §6- {tag}"
+      lore_footer: "§e§nClick to edit tags"
+    expand:
+      display: "§aExpand World"
+      lore_desc: "§7Click to §bexpand the world border"
+      level: "§f§l| §7Current Level §e§l{current}§7/{max}"
+      cost: "§f§l| §7Cost §6🛖 §e{cost} §7({level_before} §f→ §e§l{level_after}§7)"
+      cost_insufficient: "§f§l| §7Cost §6🛖 §c§n{cost}§r §8({level_before} → {level_after}) §c§n{shortage} points §cinsufficient."
+      points: "§f§l| §7Your Points §6🛖 §e{points}"
+      max_level: "§f§l| §cMaximum expansion reached!"
+    publish:
+      display: "§6Change Publish Level"
+      current: "§f§l| §7Current Setting {color}{level}"
+      active_prefix: "§6» "
+      inactive_prefix: "  "
+      desc_header: "§f§l| Description "
+      click_left: "§e§l| §e§nLeft-Click Prev"
+      click_right: "§e§l| §e§nRight-Click Next"
+    member:
+      display: "§6Member Management"
+      count: "§f§l| §7Members: §b{count}"
+      list_header: "§f§l| §bMember List"
+      role_owner: "Owner"
+      role_moderator: "Moderator"
+      role_member: "Member"
+      list_item: "  {debug_color}[{role_color}{role}{debug_color}] {name_color}{player}"
+      list_item_member: "  {name_color}{player}"
+      more_members: "  §7+{remaining} total (§a{online} online§7)"
+      click: "§e§nClick§7 to manage members"
+      promote: "§e§l| §e§nLeft-Click §7Promote to Moderator"
+      demote: "§e§l| §e§nRight-Click §7Demote to Member"
+      remove: "§e§l| §e§nShift + Left-Click §cRemove Member"
+      transfer: "§e§l| §e§nShift + Right-Click §cTransfer Owner"
+    main_info:
+      name: "§f【§a{world}§f】"
+      lore:
+        - "§8§m-----------------------"
+        - "§f§l| §f{description}"
+        - "§f§l| §7Owner §b{owner}"
+        - "§f§l| §7Expansion §e§l{level}§7/{max_level}"
+        - "§8§m-----------------------"
+        - "§f§l| §7Archive in §6{days_until_archive} days §8({archive_date})"
+        - "§f§l| §7Members §f{member_count} §8({online_count} online)"
+        - "§f§l| §7Publish Level {publish_color}{publish_level}"
+        - "§8§m-----------------------"
+        - "§f§l| §7Favorites §c{favorites}"
+        - "§f§l| §7Recent Visitors §b{visitors}"
+        - "§8§m-----------------------"
+    visitors:
+      display: "§aVisitor Management"
+      count: "§f§l| §7Current visitors §e{count}"
+      click: "§e§nClick to view/manage"
+    notification:
+      display: "§aToggle Notifications"
+      current: "§f§l| §7Current: {color}{status}"
+      "on": "ON"
+      "off": "OFF"
+      desc:
+        - "§7When ON, members will be notified"
+        - "§7when a guest visits the world."
+        - ""
+        - "§e§nClick to toggle"
+    announcement:
+      display: "§aPlayer Announcement"
+      lore:
+        - "§7Set a message to display"
+        - "§7to visitors upon arrival."
+        - ""
+        - "§e§nLeft-Click§7 Set Message"
+        - "§e§nRight-Click§7 Reset Message"
+      preview_header: "§f§l| §e§nCurrent Message"
+      preview_footer: "§e§nClick to edit/reset"
+    critical:
+      display: "§c§nCritical Settings"
+      lore:
+        - "§cPerform irreversible actions"
+        - "§clike deleting the world."
+        - ""
+        - "§e§nClick to view"
+
+  critical:
+    title: "Critical Settings"
+    reset_expansion:
+      display: "§c§nReset Expansion"
+      current: "§f§l| §7Current level §e§l{level}"
+      refund: "§f§l| §7Refund points §6🛖 §e{points}"
+      click: "§e§nClick to reset (Irreversible)"
+      unavailable: "§cCannot reset (not expanded)"
+    delete_world:
+      display: "§4§l§nDelete World"
+      lore:
+        - "§7Deletes the world permanently."
+        - "§7This action is irreversible."
+        - ""
+        - "§8§m-----------------------"
+        - "§f§l| §7Refund points: §6🛖 §e{points}"
+        - "§8(Expansion {points} + {percent}% of Creation {cost})"
+        - "§8§m-----------------------"
+        - ""
+        - "§4§lClick to DELETE (Irreversible)"
+
+  confirm:
+    reset_expansion:
+      title: "Confirm Reset"
+      lore:
+        - "§cAre you sure you want to reset?"
+        - "§7Expansion level will be reset and points refunded."
+        - "§7World border will return to initial size."
+    delete_1:
+      title: "Delete Confirm (1/2)"
+      lore:
+        - "§cAre you sure you want to DELETE?"
+        - "§7All data will be lost forever."
+        - "§7※ There will be a final confirmation."
+      next: "§cProceed"
+    delete_2:
+      title: "Final Confirmation (2/2)"
+      lore:
+        - "§4§lARE YOU POSITIVE?"
+        - "§c§lWARNING: This is the final step."
+      confirm_btn: "§4§l【CONFIRM DELETE】"
+
+  archive:
+    title: "Archive Confirm: {world}"
+    question: "§cAre you sure you want to archive?"
+    warning:
+      - "§7Access will be denied after archiving."
+      - "§7Contact an admin to restore."
+    cancel: "§aCancel"
+    cancel_desc: "§7Return to settings"
+    confirm: "§cExecute"
+    confirm_desc: "§7Archive the world"
+
+  expansion:
+    method_title: "Select Expansion Method"
+    confirm_title: "Expansion Confirmation"
+    center_expand:
+      name: "§aExpand from Center"
+      lore:
+        - "§7Expands the world border"
+        - "§7while keeping the current center."
+    direction_expand:
+      name: "§aSpecify Direction"
+      lore:
+        - "§7Expands towards a specific corner"
+        - "§7relative to your current position."
+        - "§e(Requires direction selection after)"
+    confirm_info: "§aExpansion Summary"
+    method: "§f§l| §7Method {method}"
+    method_center: "Center"
+    method_direction: "§f§l| §7Direction {direction}"
+    cost: "§f§l| §7Cost §6🛖 §e{cost}"
+    warning: "§eThis action is irreversible!"
+    execute: "§aExpand World"
+    execute_desc: "§7Spend points to expand"
+    cancel: "§cCancel"
+    cancel_desc: "§7Back to selection"
+
+  member_management:
+    title: "Member Management"
+    invite:
+      name: "§aInvite Member"
+      desc: "§eClick and type name in chat"
+    remove_confirm:
+      title: "Confirm Removal"
+      question: "§cReally remove?"
+      player: "§f§l| §7Player §f{player}"
+      world: "§f§l| §7World §f{world}"
+      warning: "§c※ They will lose access to this world."
+      cancel: "§aCancel"
+      cancel_desc: "§7Back to list"
+      confirm: "§cRemove"
+      confirm_desc: "§7Revoke membership"
+    item:
+      last_online: "§f§l| §7Last Online §f{date}"
+      role: "§f§l| §7Rank §f{role}"
+
+  visitor_management:
+    title: "Manage Visitors"
+    no_visitors: "§cThere are currently no visitors in this world."
+    kick_confirm:
+      title: "Confirm Kick: {player}"
+      question: "§cReally kick?"
+      player: "§f§l| §7Player §f{player}"
+      cancel: "§aCancel"
+      cancel_desc: "§7Back to list"
+      confirm: "§cKick"
+      confirm_desc: "§7Eject player from world"
+    item:
+      kick: "§e§l| §cRight-Click Kick"
+
+  tag_editor:
+    title: "Tag Editor"
+    status_active: "§aActive"
+    status_inactive: "§cInactive"
+    click_toggle: "§e§nClick to toggle"
+
+  admin_menu:
+    title: "Admin Menu"
+    update_data:
+      display: "§eUpdate Data"
+      lore:
+        - "§7Validate and update integrity of all"
+        - "§7world and player data."
+        - ""
+        - "§e§nClick to Confirm"
+      confirm_title: "Update Data Confirmation"
+    repair_templates:
+      display: "§eRepair Templates"
+      lore:
+        - "§7Detect missing template worlds and"
+        - "§7attempt to regenerate them."
+        - ""
+        - "§e§nClick to Confirm"
+      confirm_title: "Repair Templates Confirmation"
+    create_template:
+      display: "§aCreate Template"
+      lore:
+        - "§7Open the Template Creation Wizard."
+        - ""
+        - "§e§nClick to Start"
+    archive:
+      display: "§cExecute Archive"
+      lore:
+        - "§7Batch archive all expired worlds."
+        - ""
+        - "§e§nClick to Confirm"
+      confirm_title: "Batch Archive Confirmation"
+    convert:
+      display: "§6Convert World"
+      lore:
+        - "§7Register current world under MyWorld management."
+        - ""
+        - "§e§nLeft Click§7 Convert in Normal Mode"
+        - "§7(Rename directory for standard management)"
+        - ""
+        - "§e§nRight Click§7 Convert in Admin Mode"
+        - "§7(Keep current structure, apply management only)"
+      confirm_normal: "Convert Confirmation (Normal)"
+      confirm_admin: "Convert Confirmation (Admin)"
+    unlink:
+      display: "§cUnlink World"
+      lore:
+        - "§7Remove MyWorld configuration for this world"
+        - "§7and revert it to a normal world."
+        - "§7(World data is NOT deleted)"
+        - ""
+        - "§e§nClick to Confirm"
+      confirm_title: "Unlink Confirmation"
+    export:
+      display: "§bExport World"
+      lore:
+        - "§7Export current world as ZIP archive."
+        - ""
+        - "§e§nClick to Confirm"
+      confirm_title: "Export Confirmation"
+      target_world: "§f§l| §7Target World §b{world}"
+    info:
+      display: "§aWorld List"
+      lore:
+        - "§7View and manage all worlds."
+        - ""
+        - "§e§nClick to Open"
+    portals:
+      display: "§bPortal Management"
+      lore:
+        - "§7View list of placed portals."
+        - ""
+        - "§e§nClick to Open"
+
+  admin:
+    title: "Manage All Worlds"
+    info:
+      display: "§fStatistics"
+      total_count: "§7Results: §f{count}"
+      page: "§7Page: §f{current} / {max}"
+    world_item:
+      owner: "§f§l| §7Owner {owner}{status_color}"
+      status: "§f§l| §7Status {status}"
+      status_archived: "§cArchived"
+      status_active: "§bActive"
+      publish: "§f§l| §7Publish {color}{level}"
+      expansion: "§f§l| §7Expansion §e{level}"
+      expires_at: "§f§l| §7Multi-Archive §e{date} §8({days_remain})"
+      expire_info_remaining: "§7{days} days left"
+      expire_info_overdue: "§7{days} days overdue"
+      mspt: "§f§l| §7MSPT: §e{mspt} §7ms"
+      action_archive: "§e§l| §e§nRight-Click §7Toggle Archive"
+      action_warp: "§e§l| §b§nLeft-Click §7Warp"
+      uuid_copy_hint: "§e§l| §8Middle-Click §7Copy UUID"
+    filter:
+      archive:
+        display: "§eArchive Filter"
+        all: "All"
+        active: "Active Only"
+        archived: "Archived Only"
+      publish:
+        display: "§ePublish Filter"
+        all: "All"
+        public: "Public Only"
+        friend: "Limited Only"
+        private: "Private Only"
+        locked: "Locked Only"
+      player:
+        display: "§ePlayer Filter"
+        none: "No Filter"
+        owner: "Owner Worlds"
+        member: "Member Worlds"
+        current_type: "§f§l §7Filter Type §f{type}"
+        current_player: "§f§l §7Target Player §b{player}"
+        click_left: "§e§l §eLeft-Click §7Change Filter Type"
+        click_right: "§e§l §eRight-Click §7Set Player"
+      click_cycle: "§e§nClick to cycle"
+      click_lr: "§e§nLeft/Right-Click §7to change"
+    sort:
+      display: "§eSort Order"
+      created_desc: "Created (Newest)"
+      created_asc: "Created (Oldest)"
+      expire_asc: "Expire Date (Soon)"
+      expire_desc: "Expire Date (Later)"
+      expansion_desc: "Expansion (High)"
+      expansion_asc: "Expansion (Low)"
+      mspt_desc: "MSPT (High)"
+  
+  environment:
+    title: "Environment Settings"
+    gravity:
+      display: "§eGravity Settings"
+      current: "§f§l| §7Current Multiplier: §6{multiplier}"
+      click: "§e§nClick§7 to cycle"
+      cost: "§f§l| §7Cost: §6🛖 §e{cost}"
+      options:
+        zero: "Zero Gravity (x0.0)"
+        moon: "Moon (x0.17)"
+        mars: "Mars (x0.38)"
+        earth: "Earth (x1.0)"
+    weather:
+      display: "§bWeather Settings"
+      current: "§f§l| §7Current Weather: §b{weather}"
+      click: "§e§nClick§7 to cycle"
+      cost: "§f§l| §7Cost: §6🛖 §e{cost}"
+      desc: "§7The weather will be fixed to the selected setting."
+    biome:
+      display: "§aBiome Settings"
+      current: "§f§l| §7Current Biome: §a{biome}"
+      click: "§e§nClick§7 to cycle"
+      click_bottle_hint: "§7Click with a Bottled Biome Air to apply."
+      cost: "§f§l| §7Cost: §6🛖 §e{cost}"
+      desc: "§7Changes the biome for the entire world."
+
+
+
+  meet:
+    title: "Visit {player}"
+    title_list: "Go to Player's Place"
+    world_item:
+      current_world: "§f§l| §7Current World §f{world}"
+      click_visit: "§e§l| §e§nClick to warp"
+
+  discovery:
+    title: "Discovery"
+    world_item:
+      owner: "§f§l| §7Owner {owner}{status_color}"
+      tag: "§f§l| §7Tags §b{tags}"
+      favorite: "§f§l| §7Favorites §c{count}"
+      recent_visitors: "§f§l| §7Recent Visitors §a{count}"
+      warp: "§e§l| §e§nLeft-Click §7Warp"
+      fav_add: "§e§l| §e§nRight-Click §7Favorite"
+      fav_remove: "§e§l| §e§nRight-Click §7Unfavorite"
+    sort:
+      display: "§aSelect Sort Order"
+      current: "§7| Current: §f{sort}"
+      active: "§a» {sort}"
+      inactive: "§8- {sort}"
+      click_next: "§e§nLeft-Click §7Next"
+      click_prev: "§e§nRight-Click §7Prev"
+    tag_select:
+      display: "§aSelect Tag"
+      current: "§f§l| Current Tag §6{tag}"
+      none: "§fNone"
+      active: "§a» {tag}"
+      inactive: "§8- {tag}"
+      click_next: "§e§nLeft-Click §7Next"
+      click_reset: "§e§nRight-Click §7Reset"
+    tag_filter:
+      name: "Tag Filter"
+      current_prefix: "Current"
+      all: "All"
+      click_left: "§e§nLeft Click§7 Toggle Filter"
+      click_right: "§e§nRight Click§7 Reset Filter"
+    sort_names:
+      hot: "Popular"
+      new: "New"
+      favorites: "Favorites"
+      spotlight: "Spotlight"
+      random: "Random"
+    tag_names:
+      shop: "Shop"
+      minigame: "Minigame"
+      building: "Building"
+      facility: "Facility"
+    info:
+      display: "§fStatistics"
+      result: "§f§l| §7Results §b{count}"
+      desc: "§7Displaying worlds matching criteria."
+    no_result: "§7No worlds found matching the criteria"
+
+  favorite:
+    title: "Favorite Worlds"
+    world_item:
+      owner: "§f§l| §7Owner §b{owner}{status_color}"
+      favorite: "§f§l| §7Favorites §c{count}"
+      recent_visitors: "§f§l| §7Recent Visitors §a{count}"
+      unfavorite: "§cRight-Click to remove"
+      archived_label: "§c§l[ARCHIVED]"
+      unfavorite_archived: "§cClick to remove"
+    info:
+      display: "§fStatistics"
+      count: "§7Favorites §f{count}"
+      page: "§7Page §a{current}§7/{max}"
+    player_icon:
+      name: "§b{player}"
+      lore_count: "§f§l| §7Favorited Worlds: §a{count}"
+    
+    favorite_menu:
+      title: "Favorite Menu"
+      other_worlds:
+        name: "§aOther Worlds of this Player"
+        lore:
+          - "§7View other worlds owned by"
+          - "§7the owner of this world."
+          - ""
+          - "§e§nClick to View"
+          - "§e§nClick to View"
+      toggle:
+        name_add: "§bAdd to Favorites"
+        name_remove: "§cRemove from Favorites"
+        name_restricted: "§7Cannot Favorite"
+        lore_add: "§7Add this world to your favorites."
+        lore_remove: "§7Remove this world from your favorites."
+        lore_restricted_owner: "§cYou cannot favorite your own world."
+        lore_restricted_not_managed: "§cThis location cannot be favorited."
+        click: "§e§nClick to Toggle"
+      list:
+        name: "§dView Favorite List"
+        lore:
+          - "§7View the list of worlds you"
+          - "§7have added to your favorites."
+          - ""
+          - "§e§nClick to View"
+    
+  spotlight_confirm:
+    title: "Register to SPOTLIGHT"
+    lore:
+      - "§fDo you want to register"
+      - "§fworld \"§a{world}§f\" to §6SPOTLIGHT§f?"
+      - ""
+      - "§7Registered worlds will be displayed"
+      - "§7at the top of the discovery menu."
+
+  visit:
+    title: "{player}'s Worlds"
+    world_item:
+      owner: "§f§l| §7Owner §b{owner}{status_color}"
+      tag: "§f§l| §7Tags §b{tags}"
+      favorite: "§f§l| §7Favorites §c{count}"
+      recent_visitors: "§f§l| §7Recent Visitors §a{count}"
+      warp: "§e§l| §e§nLeft-Click §7Warp"
+      fav_add: "§e§l| §e§nRight-Click §7Favorite"
+      fav_remove: "§e§l| §e§nRight-Click §7Unfavorite"
+
+  player_world:
+    title: "My Worlds"
+    world_item:
+      owner: "§f§l| §7Owner §f{owner}"
+      publish: "§f§l| §7Publish §b{level}{status_color}"
+      favorite: "§f§l| §7Favorites §c{count}"
+      recent_visitors: "§f§l| §7Recent Visitors §a{count}"
+      warp: "§e§l| §e§nLeft-Click§7 Warp"
+      settings: "§e§l| §b§nRight-Click§7 Settings"
+      expired: "§c§nThis world is ARCHIVED."
+      expires_at: "§f§l| §7Archive in §f{days} days §8({date})"
+
+    creation_button:
+      display: "§a§lCreate New MyWorld"
+      lore:
+        - "§7Create a new personal world."
+        - "§7You can set templates and publish level."
+        - ""
+        - "§e§nClick to Start Creation"
+    
+    stats_button:
+      display: "§e{player}"
+      world_point: "§f§l| §7World Points §6🛖 {points}"
+      slot_count: "§f§l| §7World Slots §a§l{current}§7/{max}"
+      slot_full: "§cSlots are full!"
+
+  user_settings:
+    title: "User Settings"
+    notification:
+      display: "§aVisitor Notifications"
+      lore:
+        - "§7Toggle whether to receive"
+        - "§7notifications when someone visits"
+        - "§7your world."
+        - ""
+        - "§e§nClick to Toggle"
+    language:
+      display: "§aLanguage Settings"
+      format: "§f{language}"
+      lore:
+        - "§7Change the display language"
+        - "§7of the plugin."
+        - "§8§m-----------------------"
+        - "§f§l|§7Current: §f{language}"
+        - "§8§m-----------------------"
+        - "§e§nClick to cycle"
+    critical_settings_visibility:
+      display: "§aCritical Settings Visibility"
+      lore:
+        - "§7Toggle whether to show the"
+        - "§7'Critical Settings' icon in the"
+        - "§7world management menu."
+        - "§8§m-----------------------"
+        - "§f§l| §7Current State {status}"
+        - "§8§m-----------------------"
+        - "§e§nClick to Toggle"
+    meet_enabled:
+      display: "§a/meet Settings"
+      lore:
+        - "§7Toggle whether other players"
+        - "§7can see your location via the"
+        - "§7/meet command."
+        - "§8§m-----------------------"
+        - "§f§l| §7Current State {status}"
+        - "§8§m-----------------------"
+        - "§e§nClick to Toggle"
+    button:
+      display: "§6User Settings"
+      lore:
+        - "§7Change your personal settings"
+        - "§7such as language and notifications."
+        - ""
+        - "§e§nClick to open"
+
+# Messages
+messages:
+  # Settings
+  world_name_prompt: "§ePlease type the world name in chat."
+  world_desc_prompt: "§ePlease type the world description in chat."
+  world_name_change: "§aWorld name changed."
+  world_name_invalid: "§cName must be 3-16 characters."
+  world_desc_change: "§aDescription changed."
+  icon_prompt: "§eClick an item in your inventory to set as icon."
+  icon_changed: "§aWorld icon changed to \"{icon}\"."
+  icon_cancelled: "§eIcon change cancelled."
+  spawn_set_start: "§aSetting spawn point for {type}. Left-click a block while facing the desired direction."
+  spawn_guest_set: "§aGuest spawn point set."
+  spawn_member_set: "§aMember spawn point set."
+  tag_added: "§aTag \"{tag}\" added."
+  tag_removed: "§eTag \"{tag}\" removed."
+  tag_max_reached: "§cMax {limit} tags allowed."
+  
+  # Members / Visitors / Kick
+  member_invite_input: "§eType the player ID in chat to invite."
+  member_deleted: "§aMember removed."
+  owner_transfer_failed_limit: "§cTarget player has no available world slots."
+  invite_locked_error: "§cYou cannot invite players to a locked world."
+  portal_dest_locked: "§cThe destination of this portal is currently locked."
+  portal_warped: "§aWarped to \"{destination}\" via portal."
+  invite_self_error: "§cYou cannot invite yourself."
+  invite_expired: "§cInvite not found or expired."
+  invite_world_not_found: "§cWorld data not found."
+  invite_already_member: "§cAlready a member of this world."
+  invite_accepted_self: "§aYou are now a member of world【{world}】!"
+  invite_accepted_sender: "§e{player} §faccepted your invite to world【§a{world}§f】."
+  invite_sent_success: "§eSent invite to {player} for world \"§a{world}§f\"!"
+  invite_target_offline: "§cPlayer {player} is not online."
+  invite_not_in_myworld: "§cYou must be in a MyWorld to send an invitation."
+  invite_hover: "Click to join the world"
+  invite_text: "{player} invited you to \"{world}\"!"
+  invite_click_text: "«Click here to warp»"
+  member_invite_text: "{player} invited you to join \"{world}\" as a member."
+  member_invite_click: "«Click to accept»"
+  member_invite_hover: "Click to accept the member invitation"
+  visitor_notified: "§e{player} §fvisited your world!"
+  kicked: "§cYou have been kicked from this world."
+  kicked_success: "§aKicked {player}."
+  target_offline: "§cTarget player is offline."
+  target_not_in_myworld: "§cTarget player is not in a MyWorld."
+  meet_no_players: "§cThere are currently no visible players online."
+  admin_player_filter_set: "§aPlayer filter set to {player}."
+  announcement_prompt: "§eEnter announcement message in chat. (& for colors, 'cancel' to abort)"
+  announcement_set: "§aAnnouncement message set!"
+  announcement_reset: "§eAnnouncement message reset."
+  announcement_invalid_length: "§cMessage is too long. (Max {max_lines} lines, {max_length} chars per line)"
+  announcement_blocked_string: "§cMessage contains blocked string: {string}"
+  announcement_preview: "§7[Preview] {message}"
+  oage_ganbaru_messages:
+    - "§eOage is expanding the world... §7\"Heave-ho!\""
+    - "§eOage is pushing the boundaries!"
+    - "§eOage is developing new lands..."
+  oage_ganbaru_default: "§ePreparing for expansion..."
+
+  # Expansion / Delete / Archive
+  expand_direction_prompt: "§aLeft-click while facing the direction (NW, NE, SW, SE) you want to expand."
+  expand_direction_selected: "§aDirection selected: {direction}"
+  expand_complete: "§aExpansion complete! §7{level_before} §f→ §e§l{level_after} §7(Remaining: §6🛖 §e{remaining}§7)"
+  expand_failed: "§cExpansion failed (World might not be loaded)."
+  max_expansion_reached: "§cWorld is already at max level."
+  expand_insufficient_points: "§cInsufficient points. (Required: §6🛖 §e{cost}§c)"
+  expansion_reset_success: "§aExpansion reset. Refunded §6🛖 §e{points} §apoints."
+  world_delete_start: "§cDeleting world \"{world}\"..."
+  world_delete_success: "§aDeleted world and refunded §6🛖 §e{points} §apoints."
+  world_delete_fail: "§cFailed to delete world."
+  archive_start: "§eArchiving world..."
+  archive_success: "§cWorld \"{world}\" has been archived."
+  archive_failed: "§cFailed to archive world."
+
+  # Preview
+  preview_start: "§aPreviewing template \"{template}\"... §7(Press Shift to cancel)"
+  preview_end: "§ePreview ended."
+  preview_cancel: "§ePreview cancelled."
+  preview_template_not_found: "§cTemplate not found."
+  preview_world_load_failed: "§cFailed to load preview world."
+  preview_restored: "§eYou were restored to your original position after disconnecting during preview."
+
+  unarchive_start: "§eRestoring world from archive..."
+  unarchive_success: "§aWorld restored from archive."
+  unarchive_failed: "§cFailed to restore world."
+  archive_access_denied: "§cAccess denied. This world is archived."
+
+  # Warp / Load
+  warp_success: "§aWarped to world \"{world}\"."
+  warp_invite_success: "§aWarped to the invited world."
+  warp_generic: "§aWarped to world."
+  admin_warp_success: "§a§l[Admin] §aWarped to world \"{world}\"."
+  admin_warp_archived_error: "§cCannot warp to archived world. Please restore it first."
+  portal_warp_success: "§aSuccessfully moved to \"{destination}\" via portal."
+  world_loading: "§aLoading world..."
+  load_failed: "§cFailed to load world."
+  world_instance_error: "§cFailed to retrieve world instance."
+  world_not_public: "§cThis world is not currently public."
+  evacuated: "§cWorld unloaded. Moving to spawn."
+  no_in_myworld: "§cYou must be in a MyWorld to do this."
+  admin_player_filter_prompt: "§eType the player name in chat to filter."
+  
+  # Others
+  favorite_limit_reached: "§cYou have reached the favorite limit ({limit})."
+  favorite_added: "§bAdded to favorites!"
+  portal_removed: "§aPortal removed."
+  portal_bind_success: "§aPortal bound to \"{destination}\"."
+  portal_unbind_success: "§ePortal binding removed."
+  portal_bind_myworld_only: "§cPortals can only be bound inside a MyWorld."
+  portal_bind_invalid_publish: "§cOnly Public or Limited worlds can be bound."
+  portal_not_bound: "§cThis portal is not yet bound to a world."
+  portal_place_success: "§aWorld portal placed successfully."
+  portal_broken: "§eWorld portal has been broken."
+  world_created_warp: "§aMoved to the created world."
+  no_registered_worlds: "§cYou don't have any registered worlds yet."
+  status_on: "ON"
+  status_off: "OFF"
+  status_visible: "§aVisible"
+  status_hidden: "§cHidden"
+  wizard_start: "§aStarting creation wizard."
+  wizard_name_prompt: "§ePlease type the world name in chat."
+  wizard_cancel_word: "cancel"
+  unlink_success: "§aWorld unlinked successfully."
+  unlink_failed: "§cFailed to unlink world."
+  unlink_not_myworld: "§cThis world is not a MyWorld."
+  wizard_started_for: "§aWizard started for {player}."
+  creation_timeout: "§cWorld creation session timed out due to inactivity."
+  reload_success: "§aReloaded MyWorldManager configuration."
+  daily_update_success: "§aCompleted daily world updates."
+  data_update_success: "§aUpdated all world ({world_count}) and player ({player_count}) data."
+  spotlight_added: "§aRegistered world \"{world}\" to SPOTLIGHT!"
+  spotlight_removed: "§cRemoved world \"{world}\" from SPOTLIGHT."
+  spotlight_already_registered: "§cThis world is already registered to SPOTLIGHT."
+  spotlight_limit_reached: "§cSPOTLIGHT slots are full."
+  spotlight_not_in_myworld: "§cYou must be in the target MyWorld to register it."
+  spotlight_not_owner: "§cYou can only register worlds you own."
+
+  # Command Errors / Admin actions
+  invalid_field: "§cInvalid field name."
+  invalid_action: "§cInvalid action (get, set, add, remove)."
+  value_required: "§cPlease specify a value."
+  value_negative: "§cValue cannot be negative."
+  stats_get: "§b{key} §7of §e{player}§7: {value}"
+  stats_set: "§aSet {key} of {player} to {value}."
+  stats_add: "§aAdded {value} to {key} of {player}."
+  stats_remove: "§aRemoved {value} from {key} of {player}."
+  stats_remove_error: "§cError: Resulting value would be negative. (Current: {value})"
+  give_success: "§aGave {amount}x {item} to {player}."
+  no_favorites_found: "§cNo favorite worlds found."
+  invalid_item_id: "§cInvalid Item ID."
+  migration_file_not_found: "§cSource file ({file}) not found."
+  migration_disabled: "§cMigration command is disabled. Set '{config_key}' to true in config.yml."
+  migration_error: "§cError: Migration failed for {error}."
+  migration_success: "§aMigration successful. Migrated {count} items."
+  migration_archive_start: "§e{count} worlds need archiving. Starting process (ETA: {eta}s)"
+  migration_archive_progress: "§7Archive progress: {current}/{total} - {world}"
+  migration_archive_complete: "§aArchive complete ({count} worlds)"
+  migration_folder_not_found: "§c[Error] World folder not found, skipping: {path} (ID: {id})"
+  console_only: "§cThis command can only be executed from console."
+  unknown_subcommand: "§cUnknown subcommand."
+  usage_create: "§cUsage: /mwm create <player>"
+  usage_stats: "§cUsage: /mwm stats <player> <field> <action> [value]"
+  usage_stats_fields: "§7Fields: points, warp-slots, world-slots"
+  usage_give: "§cUsage: /mwm give <player> <item_id> [amount]"
+  
+  # UUID Copy
+  internal_data_extracted: "§7Extracted internal data related to MyWorld §a【{world}】§7."
+  copy_world_uuid: "§7- §b§nMyWorld UUID"
+  copy_owner_uuid: "§7- §b§nOwner UUID"
+  copy_world_uuid_hover: "Click to copy World UUID to clipboard"
+  copy_owner_uuid_hover: "Click to copy Owner UUID to clipboard"
+
+# Common Status/Roles
+status:
+  online: "Online"
+  offline: "Offline"
+role:
+  owner: "Owner"
+  moderator: "Moderator"
+  member: "Member"
+
+custom_item:
+  empty_biome_bottle:
+    name: "§fEmpty Biome Bottle (WIP)"
+    lore:
+      - "§8§m-----------------------"
+      - "§7Use in a specific biome to capture its air!"
+      - "§7The bottled air can be used for §6Biome Settings§7 in MyWorld."
+      - "§8§m-----------------------"
+  bottled_biome_air:
+    name: "§fBottled Biome Atmosphere【{biome}】"
+    lore:
+      - "§8§m-----------------------"
+      - "§7§oFilled with dense biome air."
+      - "§7Can be used for §6Biome Settings§7 in MyWorld!"
+      - "§8§m-----------------------"
+  moon_stone:
+    name: "§fMoon Stone"
+    lore:
+      - "§8§m-----------------------"
+      - "§7§oA seemingly normal stone, yet undeniably from the moon."
+      - "§7Can be used for §bGravity Settings§7 in MyWorld!"
+      - "§8§m-----------------------"
+
+biomes:
+  plains: "Plains"
+  sunflower_plains: "Sunflower Plains"
+  snowy_plains: "Snowy Plains"
+  ice_spikes: "Ice Spikes"
+  desert: "Desert"
+  swamp: "Swamp"
+  mangrove_swamp: "Mangrove Swamp"
+  forest: "Forest"
+  flower_forest: "Flower Forest"
+  birch_forest: "Birch Forest"
+  old_growth_birch_forest: "Old Growth Birch Forest"
+  dark_forest: "Dark Forest"
+  jungle: "Jungle"
+  sparse_jungle: "Sparse Jungle"
+  bamboo_jungle: "Bamboo Jungle"
+  river: "River"
+  frozen_river: "Frozen River"
+  beach: "Beach"
+  snowy_beach: "Snowy Beach"
+  stony_shore: "Stony Shore"
+  mountains: "Mountains"
+  stony_peaks: "Stony Peaks"
+  jagged_peaks: "Jagged Peaks"
+  frozen_peaks: "Frozen Peaks"
+  meadow: "Meadow"
+  cherry_grove: "Cherry Grove"
+  grove: "Grove"
+  snowy_slopes: "Snowy Slopes"
+  taiga: "Taiga"
+  snowy_taiga: "Snowy Taiga"
+  old_growth_pine_taiga: "Old Growth Pine Taiga"
+  old_growth_spruce_taiga: "Old Growth Spruce Taiga"
+  savanna: "Savanna"
+  savanna_plateau: "Savanna Plateau"
+  windswept_savanna: "Windswept Savanna"
+  badlands: "Badlands"
+  wooded_badlands: "Wooded Badlands"
+  eroded_badlands: "Eroded Badlands"
+  deep_ocean: "Deep Ocean"
+  ocean: "Ocean"
+  warm_ocean: "Warm Ocean"
+  lukewarm_ocean: "Lukewarm Ocean"
+  cold_ocean: "Cold Ocean"
+  frozen_ocean: "Frozen Ocean"
+  mushroom_fields: "Mushroom Fields"
+  dripstone_caves: "Dripstone Caves"
+  lush_caves: "Lush Caves"
+  deep_dark: "Deep Dark"
+  nether_wastes: "Nether Wastes"
+  soul_sand_valley: "Soul Sand Valley"
+  crimson_forest: "Crimson Forest"
+  warped_forest: "Warped Forest"
+  basalt_deltas: "Basalt Deltas"
+  the_end: "The End"
+  small_end_islands: "Small End Islands"
+  end_midlands: "End Midlands"
+  end_highlands: "End Highlands"
+  end_barrens: "End Barrens"
+  custom_item:
+    bottle_fill: "§aYou have bottled the biome air! (Biome: {biome})"
+  custom_item:
+    biome_world_only: "§cYou can only use this item in MyWorld."
+    no_permission: "§cYou do not have permission to change the biome."
+    partial_biome_applied: "§aApplied biome {biome} to the surrounding area!"

--- a/src/main/resources/lang/ja_jp.yml
+++ b/src/main/resources/lang/ja_jp.yml
@@ -1,2 +1,1132 @@
-  unknown_world: "未知のワールド"
-  item_not_found_hand: "§cアイテムを手に持っていません。"
+# MyWorldManager 言語ファイル (日本語)
+
+# 全般
+general:
+  prefix: "§7[§aMyWorldManager§7] "
+  no_permission: "§c権限がありません。"
+  player_only: "§cこのコマンドはプレイヤーのみ実行可能です。"
+  world_not_found: "§cワールドが見つかりませんでした。"
+  player_not_found: "§cプレイヤーが見つかりませんでした。"
+  unknown: "不明"
+  direction:
+    north_west: "北西"
+    north_east: "北東"
+    south_west: "南西"
+    south_east: "南東"
+    unknown: "不明"
+  
+  commands:
+    settings:
+      description: "個人設定メニューを表示します。"
+
+  status:
+    join_me: "Join Me"
+    ask_me: "Ask Me"
+    busy: "取り込み中"
+    description:
+      join_me: "§f誰でもあなたの場所にワープできます。"
+      ask_me: "§f承認したプレイヤーのみワープできます。"
+      busy: "§f/meetメニューに表示されず、誰もワープできません。"
+      
+  meet_request:
+    sent: "§a{target}にワープ申請を送信しました。"
+    received: "§e{player}があなたへの訪問を希望しています。"
+    accept_button: "§a§l[承認する]"
+    hover_accept: "§7クリックしてワープを承認"
+    accepted: "§a申請を承認しました。"
+    accepted_by_target: "§a{target}が訪問を承認しました！"
+  
+  language:
+    ja_jp: "日本語"
+    en_us: "English"
+
+# 公開レベル
+publish_level:
+  public: "公開"
+  friend: "限定公開"
+  private: "非公開"
+  locked: "封鎖中"
+  description:
+    public: "§f誰でも訪問可能です。ディスカバリーメニューに掲載されます。"
+    friend: "§f誰でも訪問可能ですが、ディスカバリーメニューには掲載されません。"
+    private: "§fメンバーが招待した人のみ訪問可能です。"
+    locked: "§fメンバー以外は訪問できず、ポータルからのワープもできません。"
+  
+  color:
+    public: "§a"
+    friend: "§e"
+    private: "§c"
+    locked: "§c"
+    owner: "§6"
+    moderator: "§b"
+    member: "§f"
+    online: "§a"
+    offline: "§c"
+    active: "§a"
+    inactive: "§7"
+    uuid: "§8"
+    debug: "§8"
+
+# GUI Settings
+gui:
+  common:
+    back: "§7設定へ戻る"
+    next_page: "§a次のページへ"
+    prev_page: "§a前のページへ"
+    confirm: "§a実行する"
+    confirm_desc: "§7クリックして決定します"
+    cancel: "§cキャンセル"
+    cancel_desc: "§7クリックして中断します"
+    separator: "§8§m－－－－－－－－－－－－－－－－－－"
+    status_display: "§7ステータス: {color}{status}"
+    return: "§e戻る"
+    return_desc: "§7前のメニューに戻る"
+    world_item_name: "§f【§a{world}§f】"
+    world_item_name_simple: "§f「§a{world}§f」"
+    world_desc: "§f{description}"
+    confirmation: "確認"
+    confirm_warning: "§cこの操作は重要な変更を伴います！"
+  
+  creation:
+    title_type: "ワールドタイプを選択"
+    title_template: "テンプレートを選択"
+    title_confirm: "最終確認"
+    type:
+      template:
+        name: "テンプレートから作成"
+        desc: "用意されたテンプレートからワールドを作成します。"
+      seed:
+        name: "シード値を指定"
+        desc: "シード値を指定してワールドを生成します。"
+      random:
+        name: "ランダム生成"
+        desc: "ワールドをランダムに生成します。"
+      cost: "§f§l| §7必要ポイント §6🛖 §e{cost}"
+      points: "§f§l| §7所持ポイント §6🛖 §e{points}"
+      available: "§a作成可能です！"
+      insufficient: "§cポイントが足りません。(§6🛖 §e{shortage}不足)"
+    insufficient: "§cポイントが足りません。(§6🛖 §e{shortage}不足)"
+    limit_reached: "§cワールド作成数の上限に達しています。(現在: {current}/{max})"
+    limit_reached_total: "§cサーバー全体のワールド作成数が上限（{limit}）に達しています。"
+    template_item:
+      preview_hint: "§7右クリックでプレビュー"
+    confirm:
+      name: "この内容で確定して作成"
+      world_name: "§f§l| §7ワールド名 §f{name}"
+      creation_type: "§f§l| §7作成方法 §f{type}"
+      template: "§f§l| §7テンプレート §f{template}"
+      seed: "§f§l| §7シード値 §f{seed}"
+      cost: "§f§l| §7消費ポイント §6🛖 §e{cost}"
+
+  portal:
+    title: "ポータルの設定"
+    id_format: "§8PORTAL_ID: {id}"
+    toggle_text:
+      name: "§a浮遊テキストの表示"
+      current: "§f現在の設定: {status}"
+      click: "§eクリックで切り替え"
+    destination_label: "§7行き先 "
+    color:
+      name: "§eパーティクルの色"
+      current: "§f§l| §7現在の色 {color}"
+      click: "§eクリックして変更"
+      click_prev: "§7« {color}"
+      click_next: "§7{color} »"
+    remove:
+      name: "§cポータルを撤去する"
+      desc: "§7設置されたポータルを撤去します。"
+      click: "§eクリックして実行"
+    colors:
+      white: "白色"
+      silver: "薄灰色"
+      gray: "灰色"
+      black: "黒"
+      red: "赤"
+      maroon: "濃い赤色"
+      yellow: "黄色"
+      olive: "濃い黄色"
+      lime: "黄緑色"
+      green: "緑色"
+      aqua: "空色"
+      teal: "水色"
+      blue: "青"
+      navy: "紺色"
+      fuchsia: "赤紫色"
+      purple: "紫色"
+      orange: "オレンジ色"
+
+  portal_item:
+    name: "§bワールドポータル"
+    lore_bind: "§e§l| §e右クリック§7 現在のマイワールドを§bリンク§7する"
+    lore_unbind: "§e§l| §eShift + 右クリック§7 リンクを§c解除§7する"
+    lore_dest: "§f§l| §bリンク先 §f§n{destination}"
+    lore_place: "§f右クリックで設置して§dワールドポータル§f作成します！"
+
+  template_wizard:
+    title: "テンプレート作成ウィザード"
+    name_input:
+      display: "§eテンプレート名・IDの設定"
+    desc_input:
+      display: "§eテンプレート説明文の設定"
+    icon_select:
+      display: "§eテンプレートアイコンの選択"
+    origin_set:
+      display: "§e原点座標の設定"
+    save_confirm:
+      display: "§6テンプレートを保存・登録"
+
+  unarchive_confirm:
+    title: "§6アーカイブ解除の確認"
+    lore:
+      - "§fこのワールドは現在アーカイブされています。"
+      - "§f解除してワープしますか？"
+
+
+
+  admin_portals:
+    title: "ポータルの遠隔管理"
+    portal_item:
+      name: "§bポータル: §f{id}"
+      lore_owner: "§f§l| §7所有者: §f{owner}"
+      lore_world: "§f§l| §7設置ワールド: §f{world}"
+      lore_location: "§f§l| §7座標: §f{x}, {y}, {z}"
+      lore_teleport: "§b▷ 左クリック§7でテレポート"
+      lore_remove: "§c▷ 右クリック§7で撤去"
+    sort:
+      display: "§e並び替え方法"
+      created_desc: "設置日（新しい順）"
+      created_asc: "設置日（古い順）"
+  
+  settings:
+    title: "ワールド設定({world})"
+    info:
+      display: "§aワールド情報の設定"
+      lore:
+        - "§e§l| §e§n左クリック§a ワールド名§fを変更"
+        - "§e§l| §e§n右クリック§a ワールド説明§fを変更"
+        - ""
+        - "§7クリック後、チャット欄に入力して設定します"
+    spawn:
+      display: "§aスポーン地点の設定"
+      type:
+        guest: "ゲスト用"
+        member: "メンバー用"
+      lore:
+        - "§e§l| §e§n左クリック§b ゲスト用スポーン地点§fを設定"
+        - "§e§l| §e§n右クリック§b メンバー用スポーン地点§fを設定"
+        - ""
+        - "§7クリック後、設定したい地点のブロックを"
+        - "§7クリックして決定します。"
+        - "§e※設定時のプレイヤーの向きが保存されます"
+    error:
+      must_be_in_world_lore: "§c※この設定を変更するにはワールド内にいる必要があります"
+    icon:
+      display: "§aワールドアイコンの変更"
+      lore:
+        - "§7クリックした後、インベントリ内のアイテムを"
+        - "§7クリックしてアイコンを設定します"
+    tags:
+      display: "§aワールドタグの設定"
+      lore_header: "§f§l| §7設定中のタグ"
+      lore_empty: "  §fなし"
+      lore_item: "  §6・{tag}"
+      lore_footer: "§e§nクリックしてタグを編集"
+    expand:
+      display: "§6ワールドの拡張"
+      lore_desc: "§7クリックして§bワールドのボーダーを拡張§7します"
+      level: "§f§l| §7現在の拡張レベル §e§l{current}/{max}"
+      cost: "§f§l| §7コスト §6🛖 §e{cost} §7({level_before} §f→ §e§l{level_after}§7)"
+      cost_insufficient: "§f§l| §7コスト §6🛖 §c§n{cost}§r §8({level_before} → {level_after}) §c§n{shortage}ポイント§c不足しています。"
+      points: "§f§l| §7あなたの所有ポイント §6🛖 §e{points}"
+      max_level: "§f§l| §cこれ以上拡張できません！"
+    environment:
+      display: "§aワールド環境の設定"
+      lore:
+        - "§7ワールドのバイオーム、天気、重力を"
+        - "§7変更することができます。"
+        - ""
+        - "§e§nクリックで表示"
+    publish:
+      display: "§6公開レベルの変更"
+      current: "§f§l| §7現在の設定 {color}{level}"
+      active_prefix: "§6» "
+      inactive_prefix: "  "
+      desc_header: "§f§l| §f説明 "
+      click_left: "§e§l| §e§n左クリック§7 前へ"
+      click_right: "§e§l| §e§n右クリック§7 次へ"
+    member:
+      display: "§6メンバーの管理"
+      count: "§f§l| §7現在のメンバー数 §b{count}人"
+      list_header: "§f§l| §bメンバーの一覧"
+      role_owner: "オーナー"
+      role_moderator: "モデレーター"
+      role_member: "メンバー"
+      list_item: "  {debug_color}[{role_color}{role}{debug_color}] {name_color}{player}"
+      list_item_member: "  {name_color}{player}"
+      more_members: "  §7+{remaining}人 (§a{online}人オンライン§7)"
+      click: "§e§nクリックして一覧を表示"
+      promote: "§e§l| §e§n左クリック§7 モデレーターに変更"
+      demote: "§e§l| §e§n右クリック§7 メンバーに変更"
+      remove: "§e§l| §e§nShift + 左クリック§c メンバーから削除"
+      transfer: "§e§l| §e§nShift + 右クリック§c オーナー権限を移譲"
+    main_info:
+      name: "§f【§a{world}§f】"
+      lore:
+        - "§8§m－－－－－－－－－－－－－－－－－－"
+        - "§f§l| §f{description}"
+        - "§f§l| §7オーナー §b{owner}"
+        - "§f§l| §7拡張レベル §e§l{level}§7/{max_level}"
+        - "§8§m－－－－－－－－－－－－－－－－－－"
+        - "§f§l| §7作成日 §e{created_at_date_formatted} §8({created_days_ago})"
+        - "§f§l| §7自動アーカイブまで §6{days_until_archive}日 §8({archive_date} にアーカイブ)"
+        - "§f§l| §7メンバー §f{member_count}人 §8(オンライン: {online_count}人)"
+        - "§f§l| §7公開レベル {publish_color}{publish_level}"
+        - "§8§m－－－－－－－－－－－－－－－－－－"
+        - "§f§l| §7お気に入り数 §c{favorites}"
+        - "§f§l| §7最近訪れたプレイヤー §b{visitors}人"
+        - "§8§m－－－－－－－－－－－－－－－－－－"
+    visitors:
+      display: "§a訪問中のプレイヤー一覧"
+      count: "§f§l| §7現在ワールドを訪れているプレイヤー §e{count}人"
+      click: "§e§nクリックして一覧を表示します"
+    notification:
+      display: "§a訪問通知の切り替え"
+      current: "§f§l| §7現在の設定 {color}{status}"
+      "on": "オン"
+      "off": "オフ"
+      desc:
+        - "§7オンの場合、メンバー以外の訪問者が"
+        - "§7来た際にメンバー全員に通知します"
+        - "§7個人設定からオフにすることもできます"
+        - ""
+        - "§e§nクリックして切り替え"
+    announcement:
+      display: "§aプレイヤー案内の設定"
+      lore:
+        - "§7訪問者に向けて表示する"
+        - "§7案内メッセージを設定します。"
+        - ""
+        - "§e§n左クリック§7 メッセージを設定"
+        - "§e§n右クリック§7 設定をリセット"
+      preview_header: "§f§l| §e§n現在の案内メッセージ"
+      preview_footer: "§e§nクリックして編集・リセット"
+    critical:
+      display: "§c§n重大な設定"
+      lore:
+        - "§cワールドの削除や、拡張の初期化など"
+        - "§c取り返しのつかない操作を行います。"
+        - ""
+        - "§e§nクリックして表示"
+    portals:
+      display: "§b設置済みポータルの管理"
+      lore:
+        - "§7ワールド内に設置されているポータルを"
+        - "§7一括で管理・確認します。"
+        - ""
+        - "§e§nクリックして表示"
+
+  critical:
+    title: "重大な設定"
+    reset_expansion:
+      display: "§c§nワールド拡張を初期化"
+      current: "§f§l| §7現在の拡張レベル §e§l{level}"
+      refund: "§f§l| §7返還されるポイント §6🛖 §e{points}"
+      click: "§e§nクリックして初期化を実行（この操作は取り消せません）"
+      unavailable: "§cまた拡張されていないため、初期化できません"
+    delete_world:
+      display: "§4§l§nワールドを削除"
+      lore:
+        - "§7ワールドを完全に削除します。"
+        - "§7この操作は取り消せません。"
+        - ""
+        - "§8§m－－－－－－－－－－－－－－－－－－"
+        - "§f§l| §7返還されるポイント: §6🛖 §e{points}"
+        - "§8(消費したポイントのうち、{percent}%が返還されます)"
+        - "§8§m－－－－－－－－－－－－－－－－－－"
+        - ""
+        - "§4§lクリックして削除を実行（この操作は取り消せません）"
+
+  confirm:
+    reset_expansion:
+      title: "確認"
+      lore:
+        - "§c本当に拡張を初期化しますか？"
+        - "§7ワールド拡張がリセットされ、使用したポイントが返還されます"
+        - "§7ワールドボーダーも初期サイズに戻ります"
+    delete_1:
+      title: "確認"
+      lore:
+        - "§c§n本当にワールドを削除しますか？"
+        - "§7ワールドの全データが失われ、復旧できなくなります！"
+        - "§c※次の画面でもう一度確認があります！"
+      next: "§c次へ進む"
+    delete_2:
+      title: "§n最終確認"
+      lore:
+        - "§4§l本当に本当に削除しますか？"
+        - "§c§l【警告】クリックすることでワールドを完全に削除します！"
+      confirm_btn: "§4§l【実行する】"
+
+  expansion:
+    method_title: "拡張方法の選択"
+    confirm_title: "確認"
+    center_expand:
+      name: "§a中心を変えずに拡張"
+      lore:
+        - "§7現在の中心を変更せずに"
+        - "§7ワールドを広げます"
+    direction_expand:
+      name: "§a方角を指定して拡張"
+      lore:
+        - "§7現在のワールドの四隅のいずれかへワールドを広げます"
+        - "§7(クリック後、方角の指定を行います)"
+    confirm_info: "§a拡張内容の確認"
+    method: "§f§l| §7拡張方法 {method}"
+    method_center: "中心を変えずに拡張"
+    method_direction: "§f§l| §7方角 {direction}"
+    cost: "§f§l| §7消費ポイント §6🛖 §e{cost}"
+    warning: "§eこの操作は取り消せません！"
+    execute: "§a拡張を実行"
+    execute_desc: "§7ポイントを消費して拡張します"
+    cancel: "§cキャンセル"
+    cancel_desc: "§7選択画面に戻ります"
+
+  member_management:
+    title: "ワールドメンバーの管理"
+    invite:
+      name: "§aメンバーを招待"
+      desc: "§7クリックした後、名前を入力して招待します"
+    remove_confirm:
+      title: "確認"
+      question: "§c本当に削除しますか？"
+      player: "§f§l| §7プレイヤー §f{player}"
+      world: "§f§l| §7ワールド §f{world}"
+      warning: "§c※メンバーから削除すると、このワールドへのアクセス権限が失われます"
+      cancel: "§aキャンセル"
+      cancel_desc: "§7メンバー一覧に戻る"
+      confirm: "§c削除する"
+      confirm_desc: "§7このプレイヤーをワールドメンバーから削除します"
+    item:
+      last_online: "§f§l| §7最終オンライン §f{date}"
+      role: "§f§l| §7権限 §f{role}"
+    
+    transfer_confirm:
+      title: "オーナー権限の譲渡"
+      question: "§c本当にオーナー権限を譲渡しますか？"
+      player: "§f§l| §7新しいオーナー §f{player}"
+      world: "§f§l| §7対象ワールド §f{world}"
+      warning: "§c※譲渡すると、あなたはこのワールドのオーナーではなくなります"
+      cancel: "§aキャンセル"
+      cancel_desc: "§7メンバー一覧に戻る"
+      confirm: "§c譲渡する"
+      confirm_desc: "§dこのプレイヤーにオーナー権限を譲渡します"
+
+  visitor_management:
+    title: "訪問中のプレイヤー"
+    no_visitors: "§7現在、このワールドに訪問者はいません。"
+    kick_confirm:
+      title: "確認"
+      question: "§c本当にキックしますか？"
+      player: "§f§l| §7プレイヤー §f{player}"
+      cancel: "§aキャンセル"
+      cancel_desc: "§7一覧に戻る"
+      confirm: "§cキックする"
+      confirm_desc: "§7このプレイヤーをワールドから追い出します"
+    item:
+      kick: "§e§l| §e§n右クリック§c キックする"
+
+  tag_editor:
+    title: "ワールドタグの編集"
+    status_active: "§a有効"
+    status_inactive: "§c無効"
+    click_toggle: "§e§nクリックで切り替え"
+
+  admin_menu:
+    title: "管理者メニュー"
+    update_data:
+      display: "§eデータ更新"
+      lore:
+        - "§7全ワールド・プレイヤーデータの整合性を確認し、"
+        - "§7修復・更新を行います。"
+        - ""
+        - "§e§nクリックして確認画面へ"
+      confirm_title: "データ更新の確認"
+    repair_templates:
+      display: "§eテンプレート修復"
+      lore:
+        - "§7欠損しているテンプレートワールドを検出し、"
+        - "§7再生成を試みます。"
+        - ""
+        - "§e§nクリックして確認画面へ"
+      confirm_title: "テンプレート修復の確認"
+    create_template:
+      display: "§aテンプレート作成"
+      lore:
+        - "§7テンプレート作成ウィザードを開きます。"
+        - ""
+        - "§e§nクリックして開始"
+    archive:
+      display: "§cアーカイブ実行"
+      lore:
+        - "§7期限切れのワールドを一括アーカイブします。"
+        - ""
+        - "§e§nクリックして確認画面へ"
+      confirm_title: "一括アーカイブの確認"
+    convert:
+      display: "§6ワールド変換"
+      lore:
+        - "§7現在のワールドをMyWorld管理下に登録します。"
+        - ""
+        - "§e§n左クリック§7 Normalモードで変換"
+        - "§7(ディレクトリをリネームして標準管理)"
+        - ""
+        - "§e§n右クリック§7 Adminモードで変換"
+        - "§7(現在の構成を維持して管理のみ適用)"
+      confirm_normal: "変換確認 (Normal)"
+      confirm_admin: "変換確認 (Admin)"
+    unlink:
+      display: "§c紐づけ解除"
+      lore:
+        - "§7現在のワールドのマイワールド設定を削除し、"
+        - "§7通常のワールドに戻します。"
+        - "§7(ワールドデータ自体は削除されません)"
+        - ""
+        - "§e§nクリックして確認画面へ"
+      confirm_title: "紐づけ解除の確認"
+    export:
+      display: "§bワールドのエクスポート"
+      lore:
+        - "§7現在のワールドをZIP形式でエクスポートします。"
+        - ""
+        - "§e§nクリックして確認画面へ"
+      confirm_title: "エクスポート確認"
+      target_world: "§f§l| §7対象ワールド §b{world}"
+    info:
+      display: "§aワールド一覧"
+      lore:
+        - "§7全ワールドの一覧を表示・管理します。"
+        - ""
+        - "§e§nクリックして開く"
+    portals:
+      display: "§bポータル管理"
+      lore:
+        - "§7設置済みポータルの一覧を表示します。"
+        - ""
+        - "§e§nクリックして開く"
+
+  admin:
+    title: "マイワールドの管理"
+    info:
+      display: "§f統計情報"
+      total_count: "§f§l| §7検索結果 §b{count}件"
+      page: "§7表示中: §a{page}§7/{total_pages} ページ"
+    world_item:
+      owner: "§f§l| §7オーナー {owner}{status_color}"
+      status: "§f§l| §7状態 {status}"
+      status_archived: "§cアーカイブ済み"
+      status_active: "§bアクティブ"
+      publish: "§f§l| §7公開レベル {color}{level}"
+      expansion: "§f§l| §7拡張レベル §e{level}"
+      expires_at: "§f§l| §7自動アーカイブ予定 §e{date} §8({days_remain})"
+      created_at: "§f§l| §7作成日 §e{date} §8({days_ago})"
+      created_info_days: "§7{days}日前"
+      created_info_today: "§7今日"
+      expire_info_remaining: "§7残り {days}日"
+      expire_info_overdue: "§7アーカイブから §c{days}日 経過"
+      mspt: "§f§l| §7MSPT: §e{mspt} §7ms"
+      action_archive: "§e§l| §e§n右クリック§7 アーカイブ状態を切り替え"
+      action_warp: "§e§l| §e§n左クリック§7 このワールドへ§bワープ"
+      uuid_copy_hint: "§e§l| §8ホイールクリック§7 UUIDをコピー"
+    filter:
+      archive:
+        display: "§eアーカイブフィルター"
+        all: "すべて表示"
+        active: "アクティブのみ"
+        archived: "アーカイブのみ"
+      publish:
+        display: "§e公開レベルフィルター"
+        all: "すべて表示"
+        public: "公開のみ"
+        friend: "限定公開のみ"
+        private: "非公開のみ"
+        locked: "封鎖中のみ"
+      player:
+        display: "§eプレイヤーフィルター"
+        none: "フィルターなし"
+        owner: "オーナーのワールド"
+        member: "メンバーのワールド"
+        current_type: "§f§l §7フィルタータイプ §f{type}"
+        current_player: "§f§l §7対象プレイヤー §b{player}"
+        click_left: "§e§l §e左クリック §7フィルタータイプを変更"
+        click_right: "§e§l §e右クリック §7プレイヤーを指定"
+      click_cycle: "§e§nクリックで切り替え"
+      click_lr: "§e§n左/右クリック§7 で変更"
+    sort:
+      display: "§eソート方法"
+      created_desc: "§a作成日（新しい順）"
+      created_asc: "§a作成日（古い順）"
+      expire_asc: "§aアーカイブ予定（近い順）"
+      expire_desc: "§aアーカイブ予定（遠い順）"
+      expansion_desc: "§a拡張レベル（高い順）"
+      expansion_asc: "§a拡張レベル（低い順）"
+      mspt_desc: "§aMSPT（高い順）"
+
+  environment:
+    title: "環境設定"
+    gravity:
+      display: "§e重力の設定"
+      current: "§f§l| §7現在の倍率: §6{multiplier}"
+      click_hint: "§e§n月の石§7を持った状態でクリックで変更"
+      cost: "§f§l| §7必要ポイント §6🛖 §e{cost}"
+      options:
+        zero: "無重力 (x0.0)"
+        moon: "月 (x0.17)"
+        mars: "火星 (x0.38)"
+        earth: "地球 (x1.0)"
+    weather:
+      display: "§b天候の設定"
+      current: "§f§l| §7現在の天候: §b{weather}"
+      click_cycle: "§e§n左クリック§7で切り替え"
+      click_confirm: "§d§n右クリック§7で確定・ポイント消費"
+      cost: "§f§l| §7必要ポイント §6🛖 §e{cost}"
+      desc: "§7設定した天候で固定されます。"
+    biome:
+      display: "§aバイオームの設定"
+      current: "§f§l| §7現在のバイオーム: §a{biome}"
+      click_hint: "§e§nバイオームの瓶§7を持った状態でクリックで変更"
+      click_bottle_hint: "§7バイオーム入りの瓶を持ってクリックしてください"
+      cost: "§f§l| §7必要ポイント §6🛖 §e{cost}"
+      desc: "§7ワールド全体のバイオームを変更します。"
+
+
+  meet:
+    title: "{player}のところに行く"
+    title_list: "プレイヤーのところに行く"
+    world_item:
+      current_world: "§f§l| §7現在のワールド §f{world}"
+      status: "§f§l| §7ステータス §e{status}"
+      click_visit: "§e§l| §e§nクリックしてワールドにワープ"
+      click_request: "§e§l| §e§nクリックしてワープ申請を送信"
+    settings_button:
+      display: "§6/meet 設定"
+      lore:
+        - "§7自身のステータスや設定を変更します。"
+        - ""
+        - "§e§nクリックして開く"
+
+  meet_settings:
+    title: "/meet 設定"
+    status_selector:
+      display: "§aステータス設定"
+      current: "§f§l| §7現在のステータス §e{status}"
+      active_prefix: "§6» "
+      inactive_prefix: "  "
+      desc_header: "§f§l| §f説明 "
+      click_cycle: "§e§nクリックして切り替え"
+
+  discovery:
+    title: "ワールドディスカバリー"
+    world_item:
+      owner: "§f§l| §7オーナー {owner}{status_color}"
+      tag: "§f§l| §7タグ §b{tags}"
+      favorite: "§f§l| §7お気に入り §c{count}"
+      recent_visitors: "§f§l| §7最近訪れたプレイヤー §a{count}人"
+      warp: "§e§l| §e§n左クリック§7 このワールドにワープ"
+      fav_add: "§e§l| §e§n右クリック§7 お気に入りに追加"
+      fav_remove: "§e§l| §e§n右クリック§7 お気に入りを解除"
+      spotlight_remove: "§e§l| §e§nShift+右クリック§c SPOTLIGHTから削除"
+    spotlight_empty:
+      name: "§f§l[ 未登録のSPOTLIGHT ]"
+      lore_admin:
+        - "§7現在このスロットにはワールドが登録されていません。"
+        - ""
+        - "§e§n左クリック§7 あなたのマイワールドを登録"
+        - "§7(確認画面が表示されます)"
+      lore_visitor:
+        - "§7現在このスロットにはワールドが登録されていません。"
+    sort:
+      display: "§a並び替え方法の選択"
+      current: "§7| 現在の設定: §f{sort}"
+      active: "§a» {sort}"
+      inactive: "§8- {sort}"
+      click_next: "§e§n左クリック§7 次へ"
+      click_prev: "§e§n右クリック§7 前へ"
+    tag_select:
+      display: "§aタグの選択"
+      current: "§f§l| 選択中のタグ §6{tag}"
+      none: "§fなし"
+      active: "§a» {tag}"
+      inactive: "§8- {tag}"
+      click_next: "§e§n左クリック§7 次へ"
+      click_reset: "§e§n右クリック§7 選択を解除"
+    tag_filter:
+      name: "タグフィルター"
+      current_prefix: "現在の設定"
+      all: "すべて"
+      click_left: "§e§n左クリック§7 フィルターを切り替え"
+      click_right: "§e§n右クリック§7 フィルターを解除"
+    sort_names:
+      hot: "§cHOT"
+      new: "§aNEW"
+      favorites: "§eFAVORITES"
+      spotlight: "§6SPOTLIGHT"
+      random: "§bRANDOM"
+    tag_names:
+      shop: "ショップ"
+      minigame: "ミニゲーム"
+      building: "建築"
+      facility: "共用施設"
+    info:
+      display: "§f統計情報"
+      result: "§f§l| §7検索結果 §b{count}件"
+      desc: "§7条件に一致するワールドを表示しています"
+    sort_info:
+      hot: "§7直近の来訪者が多い順"
+      new: "§7公開日時が新しい順"
+      favorites: "§7お気に入り登録数が多い順"
+      spotlight: "§7運営によるピックアップ"
+      random: "§7ランダムに表示"
+    no_result: "§7条件に一致するワールドが見つかりませんでした"
+
+  favorite:
+    title: "お気に入りリスト"
+    world_item:
+      owner: "§f§l| §7オーナー §b{owner}{status_color}"
+      favorite: "§f§l| §7お気に入りされた数 §c{count}"
+      recent_visitors: "§f§l| §7最近訪れたプレイヤー §a{count}人"
+      unfavorite: "§cShift + 右クリックでお気に入りを解除"
+      archived_label: "§c§l[アーカイブ済み]"
+      unfavorite_archived: "§cクリックしてお気に入りから削除"
+    info:
+      display: "§f統計情報"
+      count: "§7登録中 §f{count}件"
+      page: "§7表示中 §a{current}§7/{max}ページ"
+    player_icon:
+      name: "§b{player}"
+      lore_count: "§f§l| §7お気に入りしたワールド数 §a{count} §7個"
+    
+    favorite_menu:
+      title: "お気に入りメニュー"
+      other_worlds:
+        name: "§aこのプレイヤーのほかのワールド"
+        lore:
+          - "§7このワールドのオーナーが所有する"
+          - "§7ほかのワールド一覧を表示します。"
+          - ""
+          - "§e§nクリックで表示"
+          - "§e§nクリックで表示"
+      toggle:
+        name_add: "§bお気に入りに追加"
+        name_remove: "§cお気に入りから削除"
+        name_restricted: "§7お気に入り登録不可"
+        lore_add: "§7このワールドをお気に入りリストに追加します。"
+        lore_remove: "§7このワールドをお気に入りリストから削除します。"
+        lore_restricted_owner: "§c自分のワールドはお気に入り登録できません。"
+        lore_restricted_not_managed: "§cこの場所はお気に入り登録できません。"
+        click: "§e§nクリックで切り替え"
+      list:
+        name: "§dお気に入り一覧を表示"
+        lore:
+          - "§7あなたが登録したお気に入りワールドの"
+          - "§7一覧を表示します。"
+          - ""
+          - "§e§nクリックで表示"
+    
+    remove_confirm:
+      title: "お気に入り解除の確認"
+      lore:
+        - "§fワールド「§a{world}§f」を"
+        - "§cお気に入りから解除§fしますか？"
+        - ""
+        - "§7解除すると、お気に入りリストから削除されます。"
+    
+  spotlight_confirm:
+    title: "SPOTLIGHTへの登録"
+    lore:
+      - "§fワールド「§a{world}§f」を"
+      - "§6SPOTLIGHT§fに登録しますか？"
+      - ""
+      - "§7登録するとディスカバリーメニューの最上位に"
+      - "§7優先的に表示されるようになります。"
+  
+  world_seed_confirm:
+    title: "ワールドの種の使用"
+    lore:
+      - "§dワールドの種§fを使用しますか？"
+      - ""
+      - "§7現在のマイワールドスロット: §a{current}"
+      - "§7使用後のマイワールドスロット: §a{next}"
+      - ""
+      - "§7スロットを拡張すると、作成できる"
+      - "§7マイワールドの数が増えます。"
+
+  visit:
+    title: "{player}のワールド"
+    world_item:
+      owner: "§f§l| §7オーナー §b{owner}{status_color}"
+      tag: "§f§l| §7タグ §b{tags}"
+      favorite: "§f§l| §7お気に入り §c{count}"
+      recent_visitors: "§f§l| §7最近訪れたプレイヤー §a{count}人"
+      warp: "§e§l| §e§n左クリック§7 このワールドへワープ"
+      fav_add: "§e§l| §b§n右クリック§7 お気に入りに追加"
+      fav_remove: "§e§l| §c§n右クリック§7 お気に入りを解除"
+
+  player_world:
+    title: "マイワールドの一覧"
+    world_item:
+      owner: "§f§l| §7オーナー §f{owner}"
+      publish: "§f§l| §7公開設定 §b{level}{status_color}"
+      favorite: "§f§l| §7お気に入り §c{count}"
+      recent_visitors: "§f§l| §7最近訪れたプレイヤー §a{count}人"
+      warp: "§e§l| §e§n左クリック§7 このワールドへ§bワープ"
+      settings: "§e§l| §b§n右クリック§7 ワールド設定を開く"
+      expired: "§c§nこのワールドはアーカイブされています"
+      expires_at: "§f§l| §7アーカイブまでの日数 §f{days}日 §8({date})"
+    
+    creation_button:
+      display: "§a§lマイワールドを新規作成"
+      lore:
+        - "§7新しいマイワールドを作成します。"
+        - "§7テンプレートや公開範囲を自由に設定可能です。"
+        - ""
+        - "§e§nクリックして作成を開始"
+    
+    stats_button:
+      display: "§e{player}"
+      lore:
+        - "§8§m－－－－－－－－－－－－－－－－－－"
+        - "§f§l| §7ワールドポイント §6{icon} {point}"
+        - "§7マイワールドの新規作成や、拡張などに使えるポイントです"
+        - "§8§m－－－－－－－－－－－－－－－－－－"
+        - "§f§l| §7ワールドスロット §a§l{current_occupied}§7/{unlocked}"
+        - "§7新規にマイワールドを作成することができる枠数です"
+        - "§7「ワールドの種」を使用することで解放することができます"
+        - "§8§m－－－－－－－－－－－－－－－－－－"
+
+  user_settings:
+    title: "個人設定"
+    notification:
+      display: "§a訪問者の通知"
+      lore:
+        - "§7誰かがあなたのワールドを訪れたときに"
+        - "§7通知を送信するかどうかを設定します。"
+        - ""
+        - "§f§l| §7現在の状態 {status}"
+        - ""
+        - "§e§nクリックで切り替え"
+    language:
+      display: "§a言語設定"
+      format: "§f{language}"
+      lore:
+        - "§7メニューやメッセージの表示言語を変更します。"
+        - ""
+        - "§f§l| §7現在の設定: §f{language}"
+        - ""
+        - "§e§nクリックで次へ"
+    critical_settings_visibility:
+      display: "§a重大な設定の表示"
+      lore:
+        - "§7ワールド管理メニュー内の"
+        - "§7「重大な設定」アイコンを表示するか設定します。"
+        - ""
+        - "§f§l| §7現在の設定 {status}"
+        - ""
+        - "§e§nクリックで切り替え"
+        - "§f§l| §7現在の設定 {status}"
+        - ""
+        - "§e§nクリックで切り替え"
+    button:
+      display: "§6個人設定"
+      lore:
+        - "§7表示言語や通知などを変更します。"
+        - ""
+        - "§e§nクリックで開く"
+
+# メッセージ
+messages:
+  # 設定操作
+  world_name_prompt: "§eワールド名を入力してください"
+  wizard_cancel_word: "cancel" # チャットでこの単語を入力するとキャンセル
+  unlink_success: "§aワールドの紐づけを解除しました。"
+  unlink_failed: "§c解除に失敗しました。"
+  unlink_not_myworld: "§cこのワールドはマイワールドではありません。"
+  world_desc_prompt: "§eワールド説明文を入力してください"
+  world_name_change: "§aワールド名を変更しました！"
+  world_name_invalid: "§cワールド名は3〜16文字で入力してください"
+  world_desc_change: "§aワールド説明を変更しました！"
+  icon_prompt: "§eインベントリ内のアイテムをクリックして、アイコンを設定します"
+  icon_changed: "§aワールドアイコンを「{icon}」に変更しました！"
+  icon_cancelled: "§cアイコン設定をキャンセルしました"
+  world_not_found: "§cワールドが見つかりませんでした。"
+  spawn_set_start: "§e{type}スポーン地点の設定を開始しました。設置したい場所を向いてクリックしてください。"
+  spawn_guest_set: "§aゲスト用のスポーン位置を設定しました！"
+  spawn_member_set: "§aメンバー用のスポーン位置を設定しました！"
+  favorite_removed: "§cお気に入りを解除しました"
+  tag_max_reached: "§cタグは最大{limit}個まで設定可能です"
+  
+  # 招待関連
+  member_invite_input: "§e招待したいプレイヤーのIDをチャットに入力してください"
+  member_deleted: "§cメンバーを削除しました"
+  owner_transferred: "§a{old_owner}さんへオーナー権限を譲渡しました。"
+  owner_transfer_failed_limit: "§c譲渡先のプレイヤーのワールドスロットがいっぱいです"
+  invite_locked_error: "§c閉鎖中のワールドには招待できません"
+  portal_dest_locked: "§cこのポータルの先は現在閉鎖されています！"
+  portal_warped: "§aポータルで「{destination}」へワープしました！"
+  invite_expired: "§c招待が見つからないか、期限切れです"
+  invite_world_not_found: "§cワールドデータが見つかりませんでした"
+  invite_already_member: "§c既にこのワールドのメンバーです"
+  invite_accepted_self: "§aワールド【{world}】のメンバーになりました！"
+  invite_accepted_sender: "§e{player} §fさんがワールド【§a{world}§f】のメンバー招待を承諾しました"
+  invite_sent_success: "§e{player} §fさんを「§a{world}§f」に招待しました！"
+  invite_target_offline: "§c{player}さんは現在オフラインです"
+  invite_not_in_myworld: "§c招待を送信するには、マイワールドにいる必要があります！"
+  invite_hover: "クリックしてワールドに参加します"
+  invite_text: "{player}さんがあなたを【{world}】に招待しました！"
+  invite_click_text: "§e§n§lクリックしてワープ"
+  member_invite_text: "{player}さんがあなたを「{world}」のメンバーに招待しました。"
+  member_invite_click: "§e§n§lクリックして承諾"
+  member_invite_hover: "クリックしてメンバー招待を承諾します"
+  visitor_notified: "§a{player} §fさんが【§a{world}§f】を訪れました"
+  kicked: "§cこのワールドからキックされました"
+  kicked_success: "§c{player}さんをキックしました"
+  target_offline: "§cそのプレイヤーは現在オフラインです"
+  target_not_in_myworld: "§cそのプレイヤーはマイワールドに滞在していないため、ワープできません"
+  meet_no_players: "§c現在、表示可能なプレイヤーがオンラインにいません。"
+  admin_player_filter_set: "§aフィルター対象のプレイヤーを「{player}」に設定しました。"
+  announcement_prompt: "§7設定する案内メッセージをチャット欄に入力してください。§6exit§7と入力して編集を終了します。"
+  announcement_set: "§a案内メッセージを設定しました！"
+  announcement_reset: "§e案内メッセージをリセットしました。"
+  announcement_invalid_length: "§cメッセージが長すぎます。（{max_lines}行まで、各行{max_length}文字まで）"
+  announcement_blocked_string: "§c禁止文字列が含まれています: {string}"
+  announcement_preview: "§7«案内プレビュー» {message}"
+  env_gravity_changed: "§a重力を「{gravity}」に変更しました（倍率: {multiplier}）"
+  env_weather_changed: "§a天候を「{weather}」に規定しました"
+  env_biome_changed: "§aバイオームを「{biome}」に変更しました"
+  env_cost_paid: "§6🛖 §e{cost} §aポイントを消費しました。"
+  oage_ganbaru_messages:
+    - "§eおあげちゃんがワールドを拡げてくれています...§7「よいしょ！」"
+    - "§eおあげちゃんが境界線を押し広げています！"
+    - "§eおあげちゃんが新しい土地を開拓しています..."
+  oage_ganbaru_default: "§e拡張の準備をしています..."
+
+  # 拡張・削除・アーカイブ
+  expand_direction_prompt: "§a拡張したい方角（北西・北東・南西・南東）を向いて左クリックしてください"
+  expand_direction_selected: "§a指定した方角: {direction}"
+  expand_complete: "§aワールドの拡張が完了しました！ §7{level_before} §f→ §e§l{level_after} §7(残りポイント §6🛖 §e{remaining}§7)"
+  expand_failed: "§c拡張に失敗しました。スタッフに報告してください。"
+  max_expansion_reached: "§cすでに最大レベルです！"
+  expand_insufficient_points: "§c拡張に必要なポイントが足りません。 (必要ポイント §6🛖 §e{cost}§c)"
+  expansion_reset_success: "§a拡張段階を初期化し、§6🛖 §e{points} §aポイントを返還しました。"
+  world_delete_start: "§cワールド「{world}」を削除しています..."
+  world_delete_success: "§aワールドを削除し、合計 §6🛖 §e{points} §aポイントを返還しました。"
+  world_delete_fail: "§cワールドの削除に失敗しました。"
+  archive_start: "§eワールドをアーカイブしています..."
+  archive_success: "§cワールド「{world}」をアーカイブしました。"
+  archive_failed: "§cワールドのアーカイブに失敗しました。"
+
+  # プレビュー
+  preview_start: "§aテンプレート「{template}」のプレビューを開始しました… §7(Shiftキーで中断可能)"
+  preview_end: "§eプレビューが終了しました。"
+  preview_cancel: "§eプレビューをキャンセルしました。"
+  preview_template_not_found: "§cテンプレートが見つかりませんでした。"
+  preview_world_load_failed: "§cプレビュー用ワールドの読み込みに失敗しました。"
+  preview_restored: "§eプレビュー中に遊離したため、元の位置に復帰しました。"
+
+  unarchive_start: "§eワールドをアーカイブから復旧しています..."
+  unarchive_success: "§aワールドを復旧しました。"
+  unarchive_failed: "§cワールドの復旧に失敗しました。"
+  archive_access_denied: "§cこのワールドは現在アーカイブされているため、アクセスできません。"
+
+  # ワープ・ロード
+  warp_success: "§aワールド【{world}】にワープしました。"
+  warp_invite_success: "§a招待されたワールドにワープしました。"
+  warp_generic: "§aワールドにワープしました。"
+  admin_warp_success: "§aワールド【{world}】にワープしました。"
+  admin_warp_archived_error: "§cアーカイブ中のワールドには直接ワープできません。"
+  portal_warp_success: "§aポータルを介して【{destination}】へ移動しました。"
+  world_loading: "§aワールドをロードしています..."
+  load_failed: "§cワールドのロードに失敗しました。"
+  world_instance_error: "§cワールドのインスタンス取得に失敗しました。"
+  world_not_public: "§cこのワールドは現在公開されていません。"
+  evacuated: "§cワールドがアンロードされたため、スポーン地点へ移動しました。"
+  no_in_myworld: "§cマイワールド内に滞在している必要があります。"
+  admin_player_filter_prompt: "§eフィルタリングするプレイヤー名をチャットで入力してください。"
+  
+  # その他
+  favorite_limit_reached: "§cお気に入り登録上限（{limit}件）に達しているため、これ以上追加できません。"
+  favorite_added: "§bこのワールドをお気に入りに追加しました！"
+  portal_removed: "§aポータルを撤去しました"
+  portal_bind_success: "§aこのポータルを「{destination}」に紐づけました"
+  portal_unbind_success: "§eポータルの紐づけを解除しました"
+  portal_bind_myworld_only: "§cマイワールド内でのみ紐づけが可能です"
+  portal_bind_invalid_publish: "§c公開または限定公開のワールドのみ紐づけ可能です"
+  portal_not_bound: "§cこのポータルはまだワールドに紐づけられていません"
+  portal_place_success: "§aワールドポータルを設置しました"
+  no_portals_found: "§7このワールドに設置されているポータルはまだありません"
+  portal_broken: "§eワールドポータルが破壊されました"
+  world_created_warp: "§a作成されたワールドに移動しました"
+  no_registered_worlds: "§7あなたはまだマイワールドを作成していません"
+  status_on: "オン"
+  status_off: "オフ"
+  status_visible: "§a表示中"
+  status_hidden: "§c非表示"
+  wizard_start: "§aワールド作成ウィザードを開始します。"
+  wizard_name_prompt: "§eまずは作成するワールドの名前をチャットで入力してください。"
+  creation_timeout: "§c長時間操作がなかったため、ワールド作成セッションがタイムアウトしました。"
+  creation_cancelled: "§cメニューを閉じたため、ワールド作成を中断しました。"
+  wizard_started_for: "§a{player} に対してワールド作成ウィザードを開始しました。"
+  reload_success: "§aMyWorldManager の設定を再読み込みしました。"
+  daily_update_success: "§aワールドの日付更新処理（統計シフト等）を完了しました。"
+  data_update_success: "§a全てのワールドデータ ({world_count}件) とプレイヤーデータ ({player_count}件) を最新の状態に更新しました。"
+  spotlight_added: "§aワールド「{world}」をSPOTLIGHTに登録しました！"
+  spotlight_removed: "§cワールド「{world}」をSPOTLIGHTから削除しました。"
+  spotlight_already_registered: "§cこのワールドは既にSPOTLIGHTに登録されています。"
+  spotlight_limit_reached: "§cSPOTLIGHTの登録枠が上限に達しています。"
+  spotlight_not_in_myworld: "§cSPOTLIGHTに登録するには、対象のマイワールドにいる必要があります。"
+  spotlight_not_owner: "§cあなたがオーナーであるマイワールドのみ登録可能です。"
+
+  # コマンドエラー・管理者操作
+  invalid_field: "§c無効な項目名です。"
+  invalid_action: "§c無効な操作名です (get, set, add, remove)。"
+  value_required: "§c値を指定してください。"
+  value_negative: "§c負の値は設定できません。"
+  stats_get: "§e{player} §7の §b{key}§7: {value}"
+  stats_set: "§a{player} の {key} を {value} §aに設定しました。"
+  stats_add: "§a{player} の {key} に {value} §aを加算しました。"
+  stats_remove: "§a{player} の {key} から {value} §aを減算しました。"
+  stats_remove_error: "§cエラー: 減算後の値が負になります。（現在の値: {value}）"
+  give_success: "§a{player} に {item} を {amount}個 付与しました。"
+  no_favorites_found: "§cお気に入り登録しているワールドが見つかりません。"
+  invalid_item_id: "§c無効なアイテムIDです。"
+  migration_file_not_found: "§c移行元のファイル ({file}) が見つかりませんでした。"
+  migration_disabled: "§cこのコマンドは現在無効化されています。実行するには config.yml の '{config_key}' を true に設定してください。"
+  migration_error: "§cエラー: {error} の移行に失敗しました。"
+  migration_success: "§a移行が完了しました。項目数: {count}"
+  migration_archive_start: "§e{count}件のワールドがアーカイブ対象です。処理を開始します（推定: {eta}秒）"
+  migration_archive_progress: "§7アーカイブ進捗: {current}/{total} - {world}"
+  migration_archive_complete: "§aアーカイブ処理が完了しました（{count}件）"
+  migration_folder_not_found: "§c[Error] ワールドフォルダが見つからないためスキップしました: {path} (ID: {id})"
+  console_only: "§cこのコマンドはコンソールからのみ実行可能です。"
+  unknown_subcommand: "§c未定義のサブコマンドです。"
+  usage_create: "§c使用法: /mwm create <プレイヤー名>"
+  usage_stats: "§c使用法: /mwm stats <プレイヤー名> <項目> <get/set/add/remove> [値]"
+  usage_stats_fields: "§7項目: points, warp-slots, world-slots"
+  usage_give: "§c使用法: /mwm give <プレイヤー名> <アイテムID> [個数]"
+  
+  # UUIDコピー
+
+  internal_data_extracted: "§7マイワールド§a【{world}】§7に関する内部データを抽出しました。"
+  copy_world_uuid: "§7- §b§nマイワールドのUUID"
+  copy_owner_uuid: "§7- §b§nオーナーのUUID"
+  copy_world_uuid_hover: "クリックしてワールドUUIDをクリップボードにコピー"
+  copy_owner_uuid_hover: "クリックしてオーナーUUIDをクリップボードにコピー"
+
+  custom_item:
+    bottle_fill: "§aバイオームの空気を瓶に詰めました！（バイオーム: {biome}）"
+    biome_world_only: "§cこのアイテムはマイワールド内でのみ使用できます。"
+    no_permission: "§cバイオームを変更する権限がありません。"
+    partial_biome_applied: "§a周囲のバイオームを {biome} に変更しました！"
+    world_seed_expanded: "§aマイワールドスロットを拡張しました！ 現在のスロット数: {slots}"
+    world_seed_limit_reached: "§cこれ以上スロットを拡張できません。（上限: {limit}）"
+
+# 共通ステータス/ロール
+status:
+  online: "オンライン"
+  offline: "オフライン"
+role:
+  owner: "オーナー"
+  moderator: "モデレーター"
+  member: "メンバー"
+
+# 外部からの変更点
+custom_item:
+  empty_biome_bottle:
+    name: "§f空のバイオームの瓶(仮)"
+    lore:
+      - "§8§m－－－－－－－－－－－－－－－－－－"
+      - "§7特定のバイオームで使用すると、そのバイオームの空気を詰めることができます！"
+      - "§7瓶済みした空気は、マイワールドの§6バイオーム設定§7に使うことができます。"
+      - "§8§m－－－－－－－－－－－－－－－－－－"
+  bottled_biome_air:
+    name: "§fバイオームの雰囲気入りの瓶【{biome}】"
+    lore:
+      - "§8§m－－－－－－－－－－－－－－－－－－"
+      - "§7§o濃厚なバイオームの空気が詰まっている"
+      - "§7マイワールドの§6バイオーム設定§7に使うことができます！"
+      - "§8§m－－－－－－－－－－－－－－－－－－"
+  moon_stone:
+    name: "§f月の石"
+    lore:
+      - "§8§m－－－－－－－－－－－－－－－－－－"
+      - "§7§o一見普通の石に見えても、紛れもない月の石である"
+      - "§7マイワールドの§b重力設定§7に使うことができます！"
+      - "§8§m－－－－－－－－－－－－－－－－－－"
+  world_seed:
+    name: "§dワールドの種"
+    lore:
+      - "§8§m－－－－－－－－－－－－－－－－－－"
+      - "§7使用することで、§bマイワールドスロット§7を"
+      - "§71つ拡張することができます！"
+      - "§8§m－－－－－－－－－－－－－－－－－－"
+      - "§e§l| 右クリックで使用"
+      - "§8§m－－－－－－－－－－－－－－－－－－"
+
+biomes:
+  plains: "平原"
+  sunflower_plains: "ヒマワリ平原"
+  snowy_plains: "雪原"
+  ice_spikes: "樹氷"
+  desert: "砂漠"
+  swamp: "湿地"
+  mangrove_swamp: "マングローブの湿地"
+  forest: "森"
+  flower_forest: "花の森"
+  birch_forest: "シラカバの森"
+  old_growth_birch_forest: "古いシラカバの森"
+  dark_forest: "暗い森"
+  jungle: "ジャングル"
+  sparse_jungle: "まばらなジャングル"
+  bamboo_jungle: "竹林"
+  river: "川"
+  frozen_river: "凍った川"
+  beach: "砂浜"
+  snowy_beach: "雪の積もった砂浜"
+  stony_shore: "石の海岸"
+  mountains: "山岳"
+  stony_peaks: "石だらけの山頂"
+  jagged_peaks: "険しい山頂"
+  frozen_peaks: "凍った山頂"
+  meadow: "草原"
+  cherry_grove: "桜の林"
+  grove: "林"
+  snowy_slopes: "雪の斜面"
+  taiga: "タイガ"
+  snowy_taiga: "雪のタイガ"
+  old_growth_pine_taiga: "古い松のタイガ"
+  old_growth_spruce_taiga: "古いトウヒのタイガ"
+  savanna: "サバンナ"
+  savanna_plateau: "サバンナの高原"
+  windswept_savanna: "吹きらさしのサバンナ"
+  badlands: "荒野"
+  wooded_badlands: "樹木のある荒野"
+  eroded_badlands: "浸食された荒野"
+  deep_ocean: "深海"
+  ocean: "海"
+  warm_ocean: "ぬるい海"
+  lukewarm_ocean: "少しぬるい海"
+  cold_ocean: "冷たい海"
+  frozen_ocean: "凍った海"
+  mushroom_fields: "キノコ島"
+  dripstone_caves: "鍾乳洞"
+  lush_caves: "茂った洞窟"
+  deep_dark: "ディープダーク"
+  nether_wastes: "ネザーの荒野"
+  soul_sand_valley: "ソウルサンドの谷"
+  crimson_forest: "真紅の森"
+  warped_forest: "歪んだ森"
+  basalt_deltas: "玄武岩の三角州"
+  the_end: "ジ・エンド"
+  small_end_islands: "エンドの小さな島々"
+  end_midlands: "エンドの中地"
+  end_highlands: "エンドの高地"
+  end_barrens: "エンドの痩せた地"


### PR DESCRIPTION
# 概要
Issue #26 に基づき、管理者メニューのプレイヤーフィルターボタンのLoreレイアウトを変更しました。
また、本PRにはGitの不整合により破損していた言語ファイル等の復旧作業が含まれています。

# 変更点
- `WorldGui.kt`: プレイヤーフィルターのLore生成ロジックを変更（セパレーターの追加、順序変更）
- `ja_jp.yml`, `en_us.yml`: 関連メッセージの装飾変更、および破損状態からの復元
- その他: 破損していた `MyWorldManager.kt`, `WorldSeedListener.kt`, `InviteSession.kt` の復元と修正

# 検証
- ビルド成功
- 実機でのLore表示確認手配済み