### PR TITLE
fix: ワープ時の効果音再生の一元化 (#20)

### DIFF
--- a/src/main/kotlin/me/awabi2048/myworldmanager/listener/PlayerWorldListener.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/listener/PlayerWorldListener.kt
@@ -142,7 +142,7 @@ class PlayerWorldListener(private val plugin: MyWorldManager) : Listener {
                         worldData.spawnPosGuest ?: targetWorld.spawnLocation
                     }
 
-                    player.teleport(spawnLocation)
+                    plugin.worldService.teleportToWorld(player, uuid, spawnLocation)
                     player.sendMessage(lang.getMessage(player, "messages.warp_success", mapOf("world" to worldData.name)))
                     plugin.worldService.sendAnnouncementMessage(player, worldData)
                     plugin.soundManager.playClickSound(player, currentItem, "player_world")

--- a/src/main/kotlin/me/awabi2048/myworldmanager/listener/WorldSettingsListener.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/listener/WorldSettingsListener.kt
@@ -620,6 +620,7 @@ class WorldSettingsListener : Listener {
                             plugin.soundManager.playClickSound(player, item, "world_settings")
                             plugin.portalManager.addIgnorePlayer(player)
                             player.teleport(portal.getCenterLocation().add(0.0, 1.0, 0.0))
+                            plugin.soundManager.playTeleportSound(player)
                             player.sendMessage(lang.getMessage(player, "messages.warp_generic"))
                             player.closeInventory()
                         }

--- a/src/main/kotlin/me/awabi2048/myworldmanager/service/WorldService.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/service/WorldService.kt
@@ -184,7 +184,7 @@ class WorldService(
         if (player != null && player.isOnline) {
             val lang = (plugin as me.awabi2048.myworldmanager.MyWorldManager).languageManager
             player.teleport(world.spawnLocation)
-            player.playSound(player.location, org.bukkit.Sound.ENTITY_PLAYER_TELEPORT, 1.0f, 2.0f)
+            plugin.soundManager.playTeleportSound(player)
             player.sendMessage(lang.getMessage(player, "messages.world_created_warp"))
         }
     }
@@ -346,7 +346,7 @@ class WorldService(
         }
 
         player.teleport(targetLoc)
-        player.playSound(player.location, org.bukkit.Sound.ENTITY_PLAYER_TELEPORT, 1.0f, 2.0f)
+        plugin.soundManager.playTeleportSound(player)
         
         // マクロ実行
         if (runMacro) {

--- a/src/main/kotlin/me/awabi2048/myworldmanager/util/SoundManager.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/util/SoundManager.kt
@@ -137,4 +137,11 @@ class SoundManager(private val plugin: MyWorldManager) {
     fun playAdminClickSound(player: Player) {
         player.playSound(player.location, Sound.UI_BUTTON_CLICK, 1.0f, 2.0f)
     }
+
+    /**
+     * テレポート時の効果音を再生 (ENTITY_PLAYER_TELEPORT, pitch 2.0)
+     */
+    fun playTeleportSound(player: Player) {
+        player.playSound(player.location, Sound.ENTITY_PLAYER_TELEPORT, 1.0f, 2.0f)
+    }
 }


### PR DESCRIPTION
ワープ時に効果音（entity.player.teleport, pitch 2.0）を再生するように修正しました。
一元的なエントリーポイント（WorldService.teleportToWorld）を利用し、本プラグインによるワープ時に限定して再生されます。

fixes #20