### PR TITLE
ディスカバリーメニューの仕様変更 (Issue #4)

### DIFF
--- a/src/main/kotlin/me/awabi2048/myworldmanager/MyWorldManager.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/MyWorldManager.kt
@@ -48,6 +48,7 @@ class MyWorldManager : JavaPlugin() {
     lateinit var templateWizardGui: TemplateWizardGui
     lateinit var adminCommandGui: AdminCommandGui
     lateinit var spotlightConfirmGui: SpotlightConfirmGui
+    lateinit var spotlightRemoveConfirmGui: SpotlightRemoveConfirmGui
     lateinit var environmentGui: EnvironmentGui
     lateinit var environmentConfirmGui: EnvironmentConfirmGui
     lateinit var worldSeedConfirmGui: WorldSeedConfirmGui
@@ -116,6 +117,7 @@ class MyWorldManager : JavaPlugin() {
         adminCommandGui = AdminCommandGui(this)
         templateWizardGui = TemplateWizardGui(this)
         spotlightConfirmGui = SpotlightConfirmGui(this)
+        spotlightRemoveConfirmGui = SpotlightRemoveConfirmGui(this)
         environmentGui = EnvironmentGui(this)
         environmentConfirmGui = EnvironmentConfirmGui(this)
         worldSeedConfirmGui = WorldSeedConfirmGui(this)

--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/SpotlightRemoveConfirmGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/SpotlightRemoveConfirmGui.kt
@@ -1,0 +1,72 @@
+package me.awabi2048.myworldmanager.gui
+
+import me.awabi2048.myworldmanager.MyWorldManager
+import me.awabi2048.myworldmanager.model.WorldData
+import me.awabi2048.myworldmanager.util.ItemTag
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.TextDecoration
+import org.bukkit.Bukkit
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
+import java.util.*
+
+class SpotlightRemoveConfirmGui(private val plugin: MyWorldManager) {
+
+    fun open(player: Player, worldData: WorldData) {
+        val lang = plugin.languageManager
+        val title = lang.getComponent(player, "gui.discovery.spotlight_remove_confirm.title").color(NamedTextColor.GOLD).decorate(TextDecoration.BOLD)
+        me.awabi2048.myworldmanager.util.GuiHelper.playMenuSoundIfTitleChanged(plugin, player, "spotlight_remove_confirm", title, null)
+        val inventory = Bukkit.createInventory(null, 27, title)
+
+        // 背景
+        val blackPane = ItemStack(Material.BLACK_STAINED_GLASS_PANE)
+        blackPane.itemMeta = blackPane.itemMeta.apply {
+            displayName(Component.empty())
+            isHideTooltip = true
+        }
+        ItemTag.tagItem(blackPane, ItemTag.TYPE_GUI_DECORATION)
+
+        val grayPane = ItemStack(Material.GRAY_STAINED_GLASS_PANE)
+        grayPane.itemMeta = grayPane.itemMeta.apply {
+            displayName(Component.empty())
+            isHideTooltip = true
+        }
+        ItemTag.tagItem(grayPane, ItemTag.TYPE_GUI_DECORATION)
+
+        // 1行目: 黒
+        for (i in 0..8) inventory.setItem(i, blackPane)
+        // 2行目: 灰
+        for (i in 9..17) inventory.setItem(i, grayPane)
+        // 3行目: 黒
+        for (i in 18..26) inventory.setItem(i, blackPane)
+
+        // 情報
+        val infoItem = ItemStack(Material.PAPER)
+        val infoMeta = infoItem.itemMeta
+        infoMeta.displayName(lang.getComponent(player, "gui.discovery.spotlight_remove_confirm.title"))
+        infoMeta.lore(lang.getComponentList(player, "gui.discovery.spotlight_remove_confirm.lore", mapOf("world" to worldData.name)))
+        infoItem.itemMeta = infoMeta
+        inventory.setItem(13, infoItem)
+
+        // はい (11)
+        val yesItem = ItemStack(Material.LIME_CONCRETE)
+        val yesMeta = yesItem.itemMeta
+        yesMeta.displayName(lang.getComponent(player, "gui.common.confirm"))
+        yesItem.itemMeta = yesMeta
+        ItemTag.tagItem(yesItem, "spotlight_remove_confirm_yes")
+        ItemTag.setWorldUuid(yesItem, worldData.uuid)
+        inventory.setItem(11, yesItem)
+
+        // いいえ (15)
+        val noItem = ItemStack(Material.RED_CONCRETE)
+        val noMeta = noItem.itemMeta
+        noMeta.displayName(lang.getComponent(player, "gui.common.cancel"))
+        noItem.itemMeta = noMeta
+        ItemTag.tagItem(noItem, "spotlight_remove_confirm_no")
+        inventory.setItem(15, noItem)
+
+        player.openInventory(inventory)
+    }
+}

--- a/src/main/kotlin/me/awabi2048/myworldmanager/listener/DiscoveryListener.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/listener/DiscoveryListener.kt
@@ -69,10 +69,8 @@ class DiscoveryListener(private val plugin: MyWorldManager) : Listener {
                     if (event.isShiftClick) {
                         // Spotlight削除 (Shift + 右クリック)
                         if (session.sort == DiscoverySort.SPOTLIGHT && player.hasPermission("myworldmanager.admin")) {
-                            plugin.spotlightRepository.remove(uuid)
-                            player.sendMessage(lang.getMessage(player, "messages.spotlight_removed", mapOf("world" to worldData.name)))
+                            plugin.spotlightRemoveConfirmGui.open(player, worldData)
                             plugin.soundManager.playClickSound(player, item, "discovery")
-                            plugin.discoveryGui.open(player)
                             return
                         }
 

--- a/src/main/kotlin/me/awabi2048/myworldmanager/listener/SpotlightListener.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/listener/SpotlightListener.kt
@@ -17,7 +17,7 @@ class SpotlightListener(private val plugin: MyWorldManager) : Listener {
         val title = PlainTextComponentSerializer.plainText().serialize(view.title())
 
         val lang = plugin.languageManager
-        if (!lang.isKeyMatch(title, "gui.spotlight_confirm.title")) return
+        if (!lang.isKeyMatch(title, "gui.spotlight_confirm.title") && !lang.isKeyMatch(title, "gui.discovery.spotlight_remove_confirm.title")) return
         event.isCancelled = true
 
         val item = event.currentItem ?: return
@@ -42,6 +42,19 @@ class SpotlightListener(private val plugin: MyWorldManager) : Listener {
                 plugin.discoveryGui.open(player)
             }
             "spotlight_confirm_no" -> {
+                plugin.soundManager.playClickSound(player, item)
+                plugin.discoveryGui.open(player)
+            }
+            "spotlight_remove_confirm_yes" -> {
+                val uuid = ItemTag.getWorldUuid(item) ?: return
+                val worldData = plugin.worldConfigRepository.findByUuid(uuid) ?: return
+
+                plugin.spotlightRepository.remove(uuid)
+                player.sendMessage(lang.getMessage(player, "messages.spotlight_removed", mapOf("world" to worldData.name)))
+                plugin.soundManager.playClickSound(player, item)
+                plugin.discoveryGui.open(player)
+            }
+            "spotlight_remove_confirm_no" -> {
                 plugin.soundManager.playClickSound(player, item)
                 plugin.discoveryGui.open(player)
             }

--- a/src/main/resources/lang/en_us.yml
+++ b/src/main/resources/lang/en_us.yml
@@ -597,16 +597,23 @@ gui:
     tag_filter:
       name: "Tag Filter"
       current_prefix: "Current"
+      no_selection: "No selection"
       all: "All"
       click_left: "§e§nLeft Click§7 Toggle Filter"
       click_right: "§e§nRight Click§7 Reset Filter"
-    stats:
-      name: "§fStatistics"
-      sort: "§f§l| §7Sort: §b{sort}"
-      tag: "§f§l| §7Tag: §b{tag}"
-      count: "§f§l| §7Results §b{count}"
-      desc: "§7Displaying worlds matching criteria."
+    sort_info:
+      hot: "Sorted by recent visitors"
+      new: "Sorted by publication date"
+      favorites: "Sorted by number of favorites"
+      spotlight: "Hand-picked worlds by staff"
+      random: "Worlds are shuffled every time you see them"
     no_result: "§7No worlds found matching the criteria"
+
+    spotlight_remove_confirm:
+      title: "Remove from SPOTLIGHT"
+      lore:
+        - "§fDo you want to remove"
+        - "§fworld \"§a{world}§f\" from §6SPOTLIGHT§f?"
 
   favorite:
     title: "Favorite Worlds"

--- a/src/main/resources/lang/ja_jp.yml
+++ b/src/main/resources/lang/ja_jp.yml
@@ -690,6 +690,7 @@ gui:
     tag_filter:
       name: "タグフィルター"
       current_prefix: "現在の設定"
+      no_selection: "設定なし"
       all: "すべて"
       click_left: "§e§n左クリック§7 フィルターを切り替え"
       click_right: "§e§n右クリック§7 フィルターを解除"
@@ -700,12 +701,18 @@ gui:
       count: "§f§l| §7検索結果 §b{count}件"
       desc: "§7条件に一致するワールドを表示しています"
     sort_info:
-      hot: "§7直近の来訪者が多い順"
-      new: "§7公開日時が新しい順"
-      favorites: "§7お気に入り登録数が多い順"
-      spotlight: "§7運営によるピックアップ"
-      random: "§7ランダムに表示"
+      hot: "直近の来訪者が多い順"
+      new: "公開日時が新しい順"
+      favorites: "お気に入り登録数が多い順"
+      spotlight: "運営によるピックアップ"
+      random: "表示するたびにランダムに入れ替わります"
     no_result: "§7条件に一致するワールドが見つかりませんでした"
+
+    spotlight_remove_confirm:
+      title: "SPOTLIGHTからの削除"
+      lore:
+        - "§fワールド「§a{world}§f」を"
+        - "§6SPOTLIGHT§fから削除しますか？"
 
   favorite:
     title: "お気に入りリスト"


### PR DESCRIPTION
ディスカバリーメニューの仕様変更を行いました。
- 常に上位10件のみを表示（ページ機能削除）
- 背景アイテムを白ガラスに変更、結果なし時はグレー染料を表示
- タグフィルター・ソートボタンのUI改善
- SPOTLIGHT管理機能の強化（削除時の確認メニュー追加）

Closes #4