### PR TITLE
fix: issue#73 アーカイブ済みワールドの表示仕様変更

### DIFF
--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/PlayerWorldGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/PlayerWorldGui.kt
@@ -36,6 +36,7 @@ class PlayerWorldGui(private val plugin: MyWorldManager) {
                         .filter {
                                 it.owner == player.uniqueId || !it.isArchived
                         } // メンバーとして参加しているアーカイブ済みは非表示
+                        .sortedWith(compareBy<WorldData> { it.isArchived }.thenByDescending { it.createdAt })
         }
 
         fun open(player: Player, page: Int = 0, showBackButton: Boolean? = null) {
@@ -313,11 +314,13 @@ class PlayerWorldGui(private val plugin: MyWorldManager) {
 
                 if (!world.isArchived) {
                         lore.add(lang.getComponent(player, "gui.player_world.world_item.warp"))
+                } else {
+                        meta.setEnchantmentGlintOverride(true)
                 }
+
                 lore.add(lang.getComponent(player, "gui.player_world.world_item.settings"))
                 if (world.isArchived) {
                         lore.add(lang.getComponent(player, "gui.player_world.world_item.expired"))
-                        lore.add(lang.getComponent(player, "gui.common.separator"))
                 }
                 lore.add(lang.getComponent(player, "gui.common.separator"))
 

--- a/src/main/kotlin/me/awabi2048/myworldmanager/util/CustomItem.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/util/CustomItem.kt
@@ -7,6 +7,10 @@ import me.awabi2048.myworldmanager.util.LanguageManager
 import org.bukkit.NamespacedKey
 import org.bukkit.inventory.ItemFlag
 import com.google.common.collect.ArrayListMultimap
+import io.papermc.paper.datacomponent.DataComponentTypes
+import io.papermc.paper.datacomponent.item.Tool
+import io.papermc.paper.datacomponent.item.ItemAttributeModifiers
+import io.papermc.paper.datacomponent.item.CustomModelData
 
 enum class CustomItem(val id: String) {
     WORLD_PORTAL("world_portal") {
@@ -15,19 +19,20 @@ enum class CustomItem(val id: String) {
     
     EMPTY_BIOME_BOTTLE("empty_biome_bottle") {
         override fun create(lang: LanguageManager, player: Player?): ItemStack {
-            val item = ItemStack(Material.WOODEN_PICKAXE)
+            val item = ItemStack(Material.STONE_PICKAXE)
             val meta = item.itemMeta ?: return item
             
             meta.displayName(net.kyori.adventure.text.Component.text(lang.getMessage(player, "custom_item.empty_biome_bottle.name")).decoration(net.kyori.adventure.text.format.TextDecoration.ITALIC, false))
             meta.lore(lang.getMessageList(player, "custom_item.empty_biome_bottle.lore").map { net.kyori.adventure.text.Component.text(it).decoration(net.kyori.adventure.text.format.TextDecoration.ITALIC, false) })
             
             meta.setMaxStackSize(4)
-            meta.setItemModel(NamespacedKey("my_world_manager", "empty_biome_bottle"))
-            meta.setTool(null)
-            meta.setAttributeModifiers(ArrayListMultimap.create())
-            meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_ADDITIONAL_TOOLTIP)
-
+            meta.setItemModel(NamespacedKey("kota_server", "mwm_misc"))
             item.itemMeta = meta
+            
+            item.setData(DataComponentTypes.TOOL, Tool.tool().build())
+            item.setData(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes().build())
+            item.setData(DataComponentTypes.CUSTOM_MODEL_DATA, CustomModelData.customModelData().addString("empty_biome_bottle").build())
+            
             ItemTag.tagItem(item, ItemTag.TYPE_EMPTY_BIOME_BOTTLE)
             return item
         }
@@ -42,19 +47,20 @@ enum class CustomItem(val id: String) {
     
     MOON_STONE("moon_stone") {
         override fun create(lang: LanguageManager, player: Player?): ItemStack {
-            val item = ItemStack(Material.WOODEN_PICKAXE)
+            val item = ItemStack(Material.STONE_PICKAXE)
             val meta = item.itemMeta ?: return item
             
             meta.displayName(net.kyori.adventure.text.Component.text(lang.getMessage(player, "custom_item.moon_stone.name")).decoration(net.kyori.adventure.text.format.TextDecoration.ITALIC, false))
             meta.lore(lang.getMessageList(player, "custom_item.moon_stone.lore").map { net.kyori.adventure.text.Component.text(it).decoration(net.kyori.adventure.text.format.TextDecoration.ITALIC, false) })
             
             meta.setMaxStackSize(1)
-            meta.setItemModel(NamespacedKey("my_world_manager", "moon_stone"))
-            meta.setTool(null)
-            meta.setAttributeModifiers(ArrayListMultimap.create())
-            meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_ADDITIONAL_TOOLTIP)
-
+            meta.setItemModel(NamespacedKey("kota_server", "mwm_misc"))
             item.itemMeta = meta
+            
+            item.setData(DataComponentTypes.TOOL, Tool.tool().build())
+            item.setData(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes().build())
+            item.setData(DataComponentTypes.CUSTOM_MODEL_DATA, CustomModelData.customModelData().addString("moon_stone").build())
+            
             ItemTag.tagItem(item, ItemTag.TYPE_MOON_STONE)
             return item
         }
@@ -62,20 +68,20 @@ enum class CustomItem(val id: String) {
     
     WORLD_SEED("world_seed") {
         override fun create(lang: LanguageManager, player: Player?): ItemStack {
-            val item = ItemStack(Material.BEETROOT_SEEDS)
+            val item = ItemStack(Material.STONE_PICKAXE)
             val meta = item.itemMeta ?: return item
             
             meta.displayName(net.kyori.adventure.text.Component.text(lang.getMessage(player, "custom_item.world_seed.name")).decoration(net.kyori.adventure.text.format.TextDecoration.ITALIC, false))
             meta.lore(lang.getMessageList(player, "custom_item.world_seed.lore").map { net.kyori.adventure.text.Component.text(it).decoration(net.kyori.adventure.text.format.TextDecoration.ITALIC, false) })
             
             meta.setMaxStackSize(1)
-            // No custom item model unless needed, sticking to material.
-            // meta.setItemModel(NamespacedKey("my_world_manager", "world_seed")) 
-            meta.setTool(null)
-            meta.setAttributeModifiers(ArrayListMultimap.create())
-            meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_ADDITIONAL_TOOLTIP)
-
+            meta.setItemModel(NamespacedKey("kota_server", "mwm_misc"))
             item.itemMeta = meta
+            
+            item.setData(DataComponentTypes.TOOL, Tool.tool().build())
+            item.setData(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes().build())
+            item.setData(DataComponentTypes.CUSTOM_MODEL_DATA, CustomModelData.customModelData().addString("world_seed").build())
+            
             ItemTag.tagItem(item, ItemTag.TYPE_WORLD_SEED)
             return item
         }
@@ -84,7 +90,7 @@ enum class CustomItem(val id: String) {
     abstract fun create(lang: LanguageManager, player: Player?): ItemStack
     
     fun createWithBiome(lang: LanguageManager, player: Player?, biomeId: String): ItemStack {
-        val item = ItemStack(Material.WOODEN_PICKAXE)
+        val item = ItemStack(Material.STONE_PICKAXE)
         val meta = item.itemMeta ?: return item
         
         val biomeName = lang.getMessage(player, "biomes.${biomeId.lowercase()}")
@@ -92,12 +98,13 @@ enum class CustomItem(val id: String) {
         meta.lore(lang.getMessageList(player, "custom_item.bottled_biome_air.lore").map { net.kyori.adventure.text.Component.text(it).decoration(net.kyori.adventure.text.format.TextDecoration.ITALIC, false) })
         
         meta.setMaxStackSize(1)
-        meta.setItemModel(NamespacedKey("my_world_manager", "bottled_biome_air"))
-        meta.setTool(null)
-        meta.setAttributeModifiers(ArrayListMultimap.create())
-        meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_ADDITIONAL_TOOLTIP)
-
+        meta.setItemModel(NamespacedKey("kota_server", "mwm_misc"))
         item.itemMeta = meta
+        
+        item.setData(DataComponentTypes.TOOL, Tool.tool().build())
+        item.setData(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes().build())
+        item.setData(DataComponentTypes.CUSTOM_MODEL_DATA, CustomModelData.customModelData().addString("bottled_biome_air").build())
+        
         ItemTag.tagItem(item, ItemTag.TYPE_BOTTLED_BIOME_AIR)
         ItemTag.setBiomeId(item, biomeId)
         return item

--- a/src/main/kotlin/me/awabi2048/myworldmanager/util/PortalItemUtil.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/util/PortalItemUtil.kt
@@ -15,7 +15,7 @@ object PortalItemUtil {
     private val TARGET_WORLD_NAME_KEY = NamespacedKey("myworldmanager", "portal_target_world_name")
 
     fun createBasePortalItem(lang: me.awabi2048.myworldmanager.util.LanguageManager, player: org.bukkit.entity.Player?): ItemStack {
-        val item = ItemStack(Material.END_PORTAL_FRAME)
+        val item = ItemStack(Material.STONE_PICKAXE)
         val meta = item.itemMeta ?: return item
         meta.displayName(Component.text(lang.getMessage(player, "gui.portal_item.name")).decoration(TextDecoration.ITALIC, false))
         meta.lore(listOf(
@@ -23,7 +23,14 @@ object PortalItemUtil {
             Component.text(lang.getMessage(player, "gui.portal_item.lore_unbind"))
         ).map { it.decoration(TextDecoration.ITALIC, false) })
         try { meta.setMaxStackSize(1) } catch (e: Exception) {}
+
+        meta.setItemModel(NamespacedKey("kota_server", "mwm_misc"))
         item.itemMeta = meta
+        
+        item.setData(io.papermc.paper.datacomponent.DataComponentTypes.TOOL, io.papermc.paper.datacomponent.item.Tool.tool().build())
+        item.setData(io.papermc.paper.datacomponent.DataComponentTypes.ATTRIBUTE_MODIFIERS, io.papermc.paper.datacomponent.item.ItemAttributeModifiers.itemAttributes().build())
+        item.setData(io.papermc.paper.datacomponent.DataComponentTypes.CUSTOM_MODEL_DATA, io.papermc.paper.datacomponent.item.CustomModelData.customModelData().addString("world_portal").build())
+
         ItemTag.tagItem(item, ItemTag.TYPE_PORTAL)
         return item
     }


### PR DESCRIPTION
Issue #73に対応しました。
- マイワールド一覧でアーカイブ済みワールドを最後に並べる（作成日の降順も維持）
- アーカイブ済みワールドのアイコンに光沢効果（Glint）を付与
- ロアの最終行のセパレータが二重になる問題を修正
動作確認済みです。