### PR TITLE
ポータル右クリック処理とGUI条件を整理

### DIFF
--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/AdminCommandGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/AdminCommandGui.kt
@@ -3,10 +3,9 @@ package me.awabi2048.myworldmanager.gui
 import me.awabi2048.myworldmanager.MyWorldManager
 import me.awabi2048.myworldmanager.service.WorldService
 import me.awabi2048.myworldmanager.session.SettingsAction
+import me.awabi2048.myworldmanager.util.GuiItemFactory
 import me.awabi2048.myworldmanager.util.ItemTag
 import net.kyori.adventure.text.Component
-import net.kyori.adventure.text.format.NamedTextColor
-import net.kyori.adventure.text.format.TextDecoration
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
 import org.bukkit.Bukkit
@@ -29,12 +28,12 @@ class AdminCommandGui(private val plugin: MyWorldManager) {
         val inventory = Bukkit.createInventory(null, 45, title)
 
         // 背景 (黒の板ガラス)
-        val blackPane = createDecorationItem(Material.BLACK_STAINED_GLASS_PANE)
+        val blackPane = GuiItemFactory.decoration(Material.BLACK_STAINED_GLASS_PANE)
         for (i in 0..8) inventory.setItem(i, blackPane)
         for (i in 36..44) inventory.setItem(i, blackPane)
 
         // 背景 (灰色の板ガラス)
-        val grayPane = createDecorationItem(Material.GRAY_STAINED_GLASS_PANE)
+        val grayPane = GuiItemFactory.decoration(Material.GRAY_STAINED_GLASS_PANE)
         for (i in 0 until inventory.size) {
             if (inventory.getItem(i) == null) inventory.setItem(i, grayPane)
         }
@@ -326,11 +325,11 @@ class AdminCommandGui(private val plugin: MyWorldManager) {
         val lang = plugin.languageManager
         
         // 背景
-        val blackPane = createDecorationItem(Material.BLACK_STAINED_GLASS_PANE)
+        val blackPane = GuiItemFactory.decoration(Material.BLACK_STAINED_GLASS_PANE)
         for (i in 0..8) inventory.setItem(i, blackPane)
         for (i in 18..26) inventory.setItem(i, blackPane)
         
-        val grayPane = createDecorationItem(Material.GRAY_STAINED_GLASS_PANE)
+        val grayPane = GuiItemFactory.decoration(Material.GRAY_STAINED_GLASS_PANE)
         for (i in 9..17) {
              if (inventory.getItem(i) == null) inventory.setItem(i, grayPane)
         }
@@ -365,22 +364,6 @@ class AdminCommandGui(private val plugin: MyWorldManager) {
     }
 
     private fun createItem(material: Material, name: String, lore: List<String>, tagType: String): ItemStack {
-        val item = ItemStack(material)
-        val meta = item.itemMeta ?: return item
-        meta.displayName(LegacyComponentSerializer.legacySection().deserialize(name).decoration(TextDecoration.ITALIC, false))
-        meta.lore(lore.map { LegacyComponentSerializer.legacySection().deserialize(it).decoration(TextDecoration.ITALIC, false) })
-        item.itemMeta = meta
-        ItemTag.tagItem(item, tagType)
-        return item
-    }
-
-    private fun createDecorationItem(material: Material): ItemStack {
-        val item = ItemStack(material)
-        val meta = item.itemMeta ?: return item
-        meta.displayName(Component.empty())
-        meta.isHideTooltip = true
-        item.itemMeta = meta
-        ItemTag.tagItem(item, ItemTag.TYPE_GUI_DECORATION)
-        return item
+        return GuiItemFactory.textItem(material, name, lore, tagType)
     }
 }

--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/AdminPortalGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/AdminPortalGui.kt
@@ -6,6 +6,7 @@ import me.awabi2048.myworldmanager.repository.*
 import me.awabi2048.myworldmanager.session.AdminGuiSession
 import me.awabi2048.myworldmanager.session.PortalSortType
 import me.awabi2048.myworldmanager.session.SettingsAction
+import me.awabi2048.myworldmanager.util.GuiItemFactory
 import me.awabi2048.myworldmanager.util.ItemTag
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
@@ -46,7 +47,7 @@ class AdminPortalGui(private val plugin: MyWorldManager) {
         val inventory = Bukkit.createInventory(null, 54, titleComp)
 
         // 1行目を黒の板ガラスで敷き詰める
-        val blackPane = createDecorationItem(Material.BLACK_STAINED_GLASS_PANE)
+        val blackPane = GuiItemFactory.decoration(Material.BLACK_STAINED_GLASS_PANE)
         for (i in 0..8) inventory.setItem(i, blackPane)
 
         // ポータルアイテムの配置
@@ -87,7 +88,7 @@ class AdminPortalGui(private val plugin: MyWorldManager) {
         }
 
         // 背景
-        val background = createDecorationItem(Material.GRAY_STAINED_GLASS_PANE)
+        val background = GuiItemFactory.decoration(Material.GRAY_STAINED_GLASS_PANE)
         for (slot in 0 until inventory.size) {
             if (inventory.getItem(slot) == null) {
                 inventory.setItem(slot, background)
@@ -191,13 +192,4 @@ class AdminPortalGui(private val plugin: MyWorldManager) {
         return item
     }
 
-    private fun createDecorationItem(material: Material): ItemStack {
-        val item = ItemStack(material)
-        val meta = item.itemMeta ?: return item
-        meta.displayName(Component.empty())
-        meta.isHideTooltip = true
-        item.itemMeta = meta
-        ItemTag.tagItem(item, ItemTag.TYPE_GUI_DECORATION)
-        return item
-    }
 }

--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/CreationGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/CreationGui.kt
@@ -4,10 +4,10 @@ import me.awabi2048.myworldmanager.MyWorldManager
 import me.awabi2048.myworldmanager.model.*
 import me.awabi2048.myworldmanager.repository.*
 import me.awabi2048.myworldmanager.session.*
+import me.awabi2048.myworldmanager.util.GuiItemFactory
 import me.awabi2048.myworldmanager.util.ItemTag
 import me.awabi2048.myworldmanager.util.PermissionManager
 import net.kyori.adventure.text.Component
-import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.TextDecoration
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
 import org.bukkit.Bukkit
@@ -134,16 +134,6 @@ class CreationGui(private val plugin: MyWorldManager) {
         player.openInventory(inventory)
     }
 
-    private fun createDecorationItem(material: Material): ItemStack {
-        val item = ItemStack(material)
-        val meta = item.itemMeta ?: return item
-        meta.displayName(Component.empty())
-        meta.isHideTooltip = true
-        item.itemMeta = meta
-        ItemTag.tagItem(item, ItemTag.TYPE_GUI_DECORATION)
-        return item
-    }
-
     fun openConfirmation(player: Player, session: WorldCreationSession) {
         val lang = plugin.languageManager
         val titleKey = "gui.creation.title_confirm"
@@ -206,8 +196,8 @@ class CreationGui(private val plugin: MyWorldManager) {
     }
 
     private fun setupHeaderFooter(inventory: org.bukkit.inventory.Inventory, rowCount: Int) {
-        val blackPane = createDecorationItem(Material.BLACK_STAINED_GLASS_PANE)
-        val greyPane = createDecorationItem(Material.GRAY_STAINED_GLASS_PANE)
+        val blackPane = GuiItemFactory.decoration(Material.BLACK_STAINED_GLASS_PANE)
+        val greyPane = GuiItemFactory.decoration(Material.GRAY_STAINED_GLASS_PANE)
 
         for (i in 0..8) inventory.setItem(i, blackPane)
         for (i in (rowCount - 1) * 9 until rowCount * 9) inventory.setItem(i, blackPane)
@@ -225,7 +215,7 @@ class CreationGui(private val plugin: MyWorldManager) {
     }
 
     private fun fillBackground(inventory: org.bukkit.inventory.Inventory) {
-        val item = createDecorationItem(Material.GRAY_STAINED_GLASS_PANE)
+        val item = GuiItemFactory.decoration(Material.GRAY_STAINED_GLASS_PANE)
 
         for (i in 0 until inventory.size) {
             if (inventory.getItem(i) == null) {
@@ -235,15 +225,7 @@ class CreationGui(private val plugin: MyWorldManager) {
     }
 
     private fun createItem(material: Material, name: String, tag: String, lore: List<Component>): ItemStack {
-        val item = ItemStack(material)
-        val meta = item.itemMeta ?: return item
-        
-        meta.displayName(LegacyComponentSerializer.legacySection().deserialize(name).decoration(TextDecoration.ITALIC, false))
-        meta.lore(lore)
-        
-        item.itemMeta = meta
-        ItemTag.tagItem(item, tag)
-        return item
+        return GuiItemFactory.item(material, name, lore, tag)
     }
 
     private fun cleanWorldName(name: String): String {

--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/DiscoveryGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/DiscoveryGui.kt
@@ -5,8 +5,8 @@ import me.awabi2048.myworldmanager.MyWorldManager
 import me.awabi2048.myworldmanager.model.PublishLevel
 import me.awabi2048.myworldmanager.model.WorldData
 import me.awabi2048.myworldmanager.session.DiscoverySort
+import me.awabi2048.myworldmanager.util.GuiItemFactory
 import me.awabi2048.myworldmanager.util.ItemTag
-import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.TextDecoration
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
@@ -80,9 +80,9 @@ class DiscoveryGui(private val plugin: MyWorldManager) {
                         }
 
                 // 背景
-                val grayPane = createDecorationItem(Material.GRAY_STAINED_GLASS_PANE)
-                val blackPane = createDecorationItem(Material.BLACK_STAINED_GLASS_PANE)
-                val whitePane = createDecorationItem(Material.WHITE_STAINED_GLASS_PANE)
+                val grayPane = GuiItemFactory.decoration(Material.GRAY_STAINED_GLASS_PANE)
+                val blackPane = GuiItemFactory.decoration(Material.BLACK_STAINED_GLASS_PANE)
+                val whitePane = GuiItemFactory.decoration(Material.WHITE_STAINED_GLASS_PANE)
 
                 // Clear content area if reusing
                 if (player.openInventory.topInventory == inventory) {
@@ -466,16 +466,6 @@ class DiscoveryGui(private val plugin: MyWorldManager) {
                 )
                 item.itemMeta = meta
                 ItemTag.tagItem(item, ItemTag.TYPE_GUI_RETURN)
-                return item
-        }
-
-        private fun createDecorationItem(material: Material): ItemStack {
-                val item = ItemStack(material)
-                val meta = item.itemMeta ?: return item
-                meta.displayName(Component.empty())
-                meta.isHideTooltip = true
-                item.itemMeta = meta
-                ItemTag.tagItem(item, ItemTag.TYPE_GUI_DECORATION)
                 return item
         }
 

--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/FavoriteGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/FavoriteGui.kt
@@ -3,8 +3,9 @@ package me.awabi2048.myworldmanager.gui
 import me.awabi2048.myworldmanager.MyWorldManager
 import me.awabi2048.myworldmanager.model.PublishLevel
 import me.awabi2048.myworldmanager.model.WorldData
+import me.awabi2048.myworldmanager.util.GuiItemFactory
+import me.awabi2048.myworldmanager.util.GuiLoreBuilder
 import me.awabi2048.myworldmanager.util.ItemTag
-import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.TextDecoration
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
 import org.bukkit.Bukkit
@@ -87,8 +88,8 @@ class FavoriteGui(private val plugin: MyWorldManager) {
                         isGui = true
                 )
 
-                val blackPane =
-                        createDecorationItem(Material.BLACK_STAINED_GLASS_PANE, returnToWorld)
+                val blackPane = GuiItemFactory.decoration(Material.BLACK_STAINED_GLASS_PANE)
+                if (returnToWorld != null) ItemTag.setWorldUuid(blackPane, returnToWorld.uuid)
                 for (i in 0..8) inventory.setItem(i, blackPane)
                 for (i in footerStart until inventorySize) inventory.setItem(i, blackPane)
 
@@ -182,8 +183,8 @@ class FavoriteGui(private val plugin: MyWorldManager) {
                 }
                 inventory.setItem(footerStart, returnItem)
 
-                val whiteBackground =
-                        createDecorationItem(Material.WHITE_STAINED_GLASS_PANE, returnToWorld)
+                val whiteBackground = GuiItemFactory.decoration(Material.WHITE_STAINED_GLASS_PANE)
+                if (returnToWorld != null) ItemTag.setWorldUuid(whiteBackground, returnToWorld.uuid)
                 for (row in 1..3) {
                         for (col in 0..8) {
                                 val slot = row * 9 + col
@@ -193,8 +194,8 @@ class FavoriteGui(private val plugin: MyWorldManager) {
                         }
                 }
 
-                val borderBackground =
-                        createDecorationItem(Material.GRAY_STAINED_GLASS_PANE, returnToWorld)
+                val borderBackground = GuiItemFactory.decoration(Material.GRAY_STAINED_GLASS_PANE)
+                if (returnToWorld != null) ItemTag.setWorldUuid(borderBackground, returnToWorld.uuid)
                 for (slot in 0 until inventory.size) {
                         if (inventory.getItem(slot) == null) {
                                 inventory.setItem(slot, borderBackground)
@@ -293,17 +294,13 @@ class FavoriteGui(private val plugin: MyWorldManager) {
 
         private fun createBackButton(player: Player, returnToWorld: WorldData?): ItemStack {
                 val lang = plugin.languageManager
-                val item = ItemStack(Material.REDSTONE)
-                val meta = item.itemMeta ?: return item
-                meta.displayName(
+                val item = GuiItemFactory.item(
+                        Material.REDSTONE,
                         lang.getComponent(player, "gui.common.return")
-                                .decorate(TextDecoration.BOLD)
+                                .decorate(TextDecoration.BOLD),
+                        if (returnToWorld != null) listOf(lang.getComponent(player, "gui.common.return_desc")) else emptyList(),
+                        ItemTag.TYPE_GUI_RETURN
                 )
-                if (returnToWorld != null) {
-                        meta.lore(listOf(lang.getComponent(player, "gui.common.return_desc")))
-                }
-                item.itemMeta = meta
-                ItemTag.tagItem(item, ItemTag.TYPE_GUI_RETURN)
                 if (returnToWorld != null) ItemTag.setWorldUuid(item, returnToWorld.uuid)
                 return item
         }
@@ -351,34 +348,21 @@ class FavoriteGui(private val plugin: MyWorldManager) {
                         ).decoration(TextDecoration.ITALIC, false)
                 )
 
-                val lore = mutableListOf<Component>()
-                lore.add(lang.getComponent(player, "gui.common.separator"))
-                lore.add(
-                        lang.getComponent(
-                                player,
-                                "gui.favorite.player_icon.lore_count",
-                                mapOf("count" to totalCount)
+                val lore = GuiLoreBuilder(lang, player)
+                        .componentBlock(
+                                listOf(
+                                        lang.getComponent(
+                                                player,
+                                                "gui.favorite.player_icon.lore_count",
+                                                mapOf("count" to totalCount)
+                                        )
+                                )
                         )
-                )
-                lore.add(lang.getComponent(player, "gui.common.separator"))
+                        .build()
 
                 meta.lore(lore)
                 item.itemMeta = meta
                 ItemTag.tagItem(item, ItemTag.TYPE_GUI_INFO)
-                return item
-        }
-
-        private fun createDecorationItem(
-                material: Material,
-                returnToWorld: WorldData? = null
-        ): ItemStack {
-                val item = ItemStack(material)
-                val meta = item.itemMeta ?: return item
-                meta.displayName(Component.empty())
-                meta.isHideTooltip = true
-                item.itemMeta = meta
-                ItemTag.tagItem(item, ItemTag.TYPE_GUI_DECORATION)
-                if (returnToWorld != null) ItemTag.setWorldUuid(item, returnToWorld.uuid)
                 return item
         }
 

--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/FavoriteMenuGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/FavoriteMenuGui.kt
@@ -2,8 +2,9 @@ package me.awabi2048.myworldmanager.gui
 
 import me.awabi2048.myworldmanager.MyWorldManager
 import me.awabi2048.myworldmanager.model.WorldData
+import me.awabi2048.myworldmanager.util.GuiItemFactory
+import me.awabi2048.myworldmanager.util.GuiLoreBuilder
 import me.awabi2048.myworldmanager.util.ItemTag
-import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
 import org.bukkit.Bukkit
 import org.bukkit.Material
@@ -29,8 +30,12 @@ class FavoriteMenuGui(private val plugin: MyWorldManager) {
             isGui = true
         )
 
-        val blackPane = createDecorationItem(Material.BLACK_STAINED_GLASS_PANE, worldData)
-        val grayPane = createDecorationItem(Material.GRAY_STAINED_GLASS_PANE, worldData)
+        val blackPane = GuiItemFactory.decoration(Material.BLACK_STAINED_GLASS_PANE)
+        val grayPane = GuiItemFactory.decoration(Material.GRAY_STAINED_GLASS_PANE)
+        if (worldData != null) {
+            ItemTag.setWorldUuid(blackPane, worldData.uuid)
+            ItemTag.setWorldUuid(grayPane, worldData.uuid)
+        }
 
         // 背景配置
         for (i in 0 until 45) {
@@ -115,9 +120,10 @@ class FavoriteMenuGui(private val plugin: MyWorldManager) {
         val loreKey = if (isFavorite) "gui.favorite.favorite_menu.toggle.lore_remove" else "gui.favorite.favorite_menu.toggle.lore_add"
         
         meta.displayName(lang.getComponent(player, nameKey).decoration(net.kyori.adventure.text.format.TextDecoration.ITALIC, false))
-        val lore = mutableListOf<Component>()
-        lore.add(lang.getComponent(player, loreKey))
-        lore.add(lang.getComponent(player, "gui.favorite.favorite_menu.toggle.click"))
+        val lore = GuiLoreBuilder(lang, player)
+            .componentBlock(listOf(lang.getComponent(player, loreKey)))
+            .componentBlock(listOf(lang.getComponent(player, "gui.favorite.favorite_menu.toggle.click")))
+            .build()
         meta.lore(lore)
         
         item.itemMeta = meta
@@ -182,17 +188,6 @@ class FavoriteMenuGui(private val plugin: MyWorldManager) {
         item.itemMeta = meta
         ItemTag.tagItem(item, ItemTag.TYPE_GUI_INFO)
         ItemTag.setWorldUuid(item, worldData.uuid)
-        return item
-    }
-
-    private fun createDecorationItem(material: Material, worldData: WorldData? = null): ItemStack {
-        val item = ItemStack(material)
-        val meta = item.itemMeta ?: return item
-        meta.displayName(Component.empty())
-        meta.isHideTooltip = true
-        item.itemMeta = meta
-        ItemTag.tagItem(item, ItemTag.TYPE_GUI_DECORATION)
-        if (worldData != null) ItemTag.setWorldUuid(item, worldData.uuid)
         return item
     }
 

--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/InviteGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/InviteGui.kt
@@ -1,8 +1,9 @@
 package me.awabi2048.myworldmanager.gui
 
 import me.awabi2048.myworldmanager.MyWorldManager
+import me.awabi2048.myworldmanager.util.GuiItemFactory
+import me.awabi2048.myworldmanager.util.GuiLoreBuilder
 import me.awabi2048.myworldmanager.util.ItemTag
-import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.TextDecoration
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
 import org.bukkit.Bukkit
@@ -51,8 +52,8 @@ class InviteGui(private val plugin: MyWorldManager) {
         val inventory = Bukkit.createInventory(holder, rowCount * 9, title)
         holder.inv = inventory
 
-        val blackPane = createDecorationItem(Material.BLACK_STAINED_GLASS_PANE)
-        val greyPane = createDecorationItem(Material.GRAY_STAINED_GLASS_PANE)
+        val blackPane = GuiItemFactory.decoration(Material.BLACK_STAINED_GLASS_PANE)
+        val greyPane = GuiItemFactory.decoration(Material.GRAY_STAINED_GLASS_PANE)
 
         for (i in 0..8) inventory.setItem(i, blackPane)
         for (i in (rowCount - 1) * 9 until rowCount * 9) inventory.setItem(i, blackPane)
@@ -103,32 +104,19 @@ class InviteGui(private val plugin: MyWorldManager) {
                 .decoration(TextDecoration.ITALIC, false)
         )
 
-        val lore = mutableListOf<Component>()
-        lore.add(lang.getComponent(viewer, "gui.common.separator"))
-
         val status = plugin.playerStatsRepository.findByUuid(target.uniqueId).meetStatus
         val statusKey = "general.status.${status.lowercase()}"
         val statusName = if (lang.hasKey(viewer, statusKey)) lang.getMessage(viewer, statusKey) else status
-        lore.add(lang.getComponent(viewer, "gui.meet.world_item.status", mapOf("status" to statusName)))
-        lore.add(lang.getComponent(viewer, "gui.common.separator"))
-        lore.add(lang.getComponent(viewer, "gui.invite.target_head.click_invite"))
-        lore.add(lang.getComponent(viewer, "gui.common.separator"))
+        val lore = GuiLoreBuilder(lang, viewer)
+            .componentBlock(listOf(lang.getComponent(viewer, "gui.meet.world_item.status", mapOf("status" to statusName))))
+            .componentBlock(listOf(lang.getComponent(viewer, "gui.invite.target_head.click_invite")))
+            .build()
 
         meta.lore(lore)
         item.itemMeta = meta
         ItemTag.tagItem(item, ItemTag.TYPE_GUI_INVITE_TARGET_HEAD)
         ItemTag.setString(item, "invite_target_uuid", target.uniqueId.toString())
         ItemTag.setString(item, "invite_target_name", target.name)
-        return item
-    }
-
-    private fun createDecorationItem(material: Material): ItemStack {
-        val item = ItemStack(material)
-        val meta = item.itemMeta ?: return item
-        meta.displayName(Component.empty())
-        meta.isHideTooltip = true
-        item.itemMeta = meta
-        ItemTag.tagItem(item, ItemTag.TYPE_GUI_DECORATION)
         return item
     }
 

--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/MeetGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/MeetGui.kt
@@ -2,6 +2,8 @@ package me.awabi2048.myworldmanager.gui
 
 import me.awabi2048.myworldmanager.MyWorldManager
 import me.awabi2048.myworldmanager.model.PublishLevel
+import me.awabi2048.myworldmanager.util.GuiItemFactory
+import me.awabi2048.myworldmanager.util.GuiLoreBuilder
 import me.awabi2048.myworldmanager.util.ItemTag
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.TextDecoration
@@ -65,8 +67,8 @@ class MeetGui(private val plugin: MyWorldManager) {
         val inventory = Bukkit.createInventory(holder, 45, title)
         holder.inv = inventory
 
-        val blackPane = createDecorationItem(Material.BLACK_STAINED_GLASS_PANE)
-        val greyPane = createDecorationItem(Material.GRAY_STAINED_GLASS_PANE)
+        val blackPane = GuiItemFactory.decoration(Material.BLACK_STAINED_GLASS_PANE)
+        val greyPane = GuiItemFactory.decoration(Material.GRAY_STAINED_GLASS_PANE)
 
         for (i in 0..8) inventory.setItem(i, blackPane)
         for (i in 36 until 45) inventory.setItem(i, blackPane)
@@ -91,18 +93,17 @@ class MeetGui(private val plugin: MyWorldManager) {
         val statusNameKey = "general.status.${currentStatus.lowercase()}"
         val statusName = if (lang.hasKey(player, statusNameKey)) lang.getMessage(player, statusNameKey) else currentStatus
 
-        val statusLore = mutableListOf<String>()
-        statusLore.add(lang.getMessage(player, "gui.common.separator"))
-        statusLore.add(lang.getMessage(player, "gui.meet.status_button.current", mapOf("status" to statusName)))
-        statusLore.add(lang.getMessage(player, "gui.meet.status_button.click"))
-        statusLore.add(lang.getMessage(player, "gui.common.separator"))
+        val statusLore = GuiLoreBuilder(lang, player)
+            .block(listOf(lang.getMessage(player, "gui.meet.status_button.current", mapOf("status" to statusName))))
+            .action(lang.getMessage(player, "gui.meet.status_button.click"))
+            .build()
 
         val statusItem = ItemStack(Material.PLAYER_HEAD)
         val statusMeta = statusItem.itemMeta as? org.bukkit.inventory.meta.SkullMeta
         if (statusMeta != null) {
             statusMeta.owningPlayer = player
             statusMeta.displayName(LegacyComponentSerializer.legacySection().deserialize(lang.getMessage(player, "gui.meet.status_button.display", mapOf("player" to player.name))).decoration(TextDecoration.ITALIC, false))
-            statusMeta.lore(statusLore.map { LegacyComponentSerializer.legacySection().deserialize(it).decoration(TextDecoration.ITALIC, false) })
+            statusMeta.lore(statusLore)
             statusItem.itemMeta = statusMeta
         }
         ItemTag.tagItem(statusItem, ItemTag.TYPE_GUI_MEET_STATUS_TOGGLE)
@@ -209,28 +210,6 @@ class MeetGui(private val plugin: MyWorldManager) {
         
         // タグ付け
         ItemTag.tagItem(item, "gui_meet_target_head")
-        return item
-    }
-
-    private fun createItem(material: Material, name: String, loreLines: List<String>, tag: String): ItemStack {
-        val item = ItemStack(material)
-        val meta = item.itemMeta ?: return item
-        
-        meta.displayName(LegacyComponentSerializer.legacySection().deserialize(name).decoration(TextDecoration.ITALIC, false))
-        meta.lore(loreLines.map { LegacyComponentSerializer.legacySection().deserialize(it).decoration(TextDecoration.ITALIC, false) })
-        
-        item.itemMeta = meta
-        ItemTag.tagItem(item, tag)
-        return item
-    }
-
-    private fun createDecorationItem(material: Material): ItemStack {
-        val item = ItemStack(material)
-        val meta = item.itemMeta ?: return item
-        meta.displayName(Component.empty())
-        meta.isHideTooltip = true
-        item.itemMeta = meta
-        ItemTag.tagItem(item, ItemTag.TYPE_GUI_DECORATION)
         return item
     }
 

--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/PendingInteractionGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/PendingInteractionGui.kt
@@ -2,6 +2,7 @@ package me.awabi2048.myworldmanager.gui
 
 import me.awabi2048.myworldmanager.MyWorldManager
 import me.awabi2048.myworldmanager.service.PendingDecisionManager
+import me.awabi2048.myworldmanager.util.GuiItemFactory
 import me.awabi2048.myworldmanager.util.ItemTag
 import me.awabi2048.myworldmanager.util.PlayerNameUtil
 import net.kyori.adventure.key.Key
@@ -355,13 +356,7 @@ class PendingInteractionGui(private val plugin: MyWorldManager) {
     }
 
     private fun createDecorationItem(material: Material): ItemStack {
-        val item = ItemStack(material)
-        val meta = item.itemMeta ?: return item
-        meta.displayName(Component.empty())
-        meta.isHideTooltip = true
-        item.itemMeta = meta
-        ItemTag.tagItem(item, ItemTag.TYPE_GUI_DECORATION)
-        return item
+        return GuiItemFactory.decoration(material)
     }
 
     class PendingInteractionHolder(

--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/PendingInteractionItemFactory.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/PendingInteractionItemFactory.kt
@@ -2,9 +2,9 @@ package me.awabi2048.myworldmanager.gui
 
 import me.awabi2048.myworldmanager.MyWorldManager
 import me.awabi2048.myworldmanager.service.PendingDecisionManager
+import me.awabi2048.myworldmanager.util.GuiLoreBuilder
 import me.awabi2048.myworldmanager.util.ItemTag
 import me.awabi2048.myworldmanager.util.PlayerNameUtil
-import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.TextDecoration
 import org.bukkit.Bukkit
 import org.bukkit.entity.Player
@@ -51,40 +51,46 @@ object PendingInteractionItemFactory {
             ).decoration(TextDecoration.ITALIC, false)
         )
 
-        val lore = mutableListOf<Component>()
-        lore += lang.getComponent(viewer, "gui.common.separator")
-        lore += lang.getComponent(
-            viewer,
-            "gui.pending_list.item.type_line",
-            mapOf("type" to typeLabel(plugin, viewer, type))
-        )
-        lore += lang.getComponent(
-            viewer,
-            "gui.pending_list.item.world_line",
-            mapOf("world" to worldName)
-        )
-        lore += lang.getComponent(
-            viewer,
-            "gui.pending_list.item.status_line",
-            mapOf(
-                "status" to lang.getMessage(
-                    viewer,
-                    if (isOnline) "gui.pending_list.item.status_online" else "gui.pending_list.item.status_offline"
+        val lore = GuiLoreBuilder(lang, viewer)
+            .componentBlock(
+                listOf(
+                    lang.getComponent(
+                        viewer,
+                        "gui.pending_list.item.type_line",
+                        mapOf("type" to typeLabel(plugin, viewer, type))
+                    ),
+                    lang.getComponent(
+                        viewer,
+                        "gui.pending_list.item.world_line",
+                        mapOf("world" to worldName)
+                    ),
+                    lang.getComponent(
+                        viewer,
+                        "gui.pending_list.item.status_line",
+                        mapOf(
+                            "status" to lang.getMessage(
+                                viewer,
+                                if (isOnline) "gui.pending_list.item.status_online" else "gui.pending_list.item.status_offline"
+                            )
+                        )
+                    ),
+                    lang.getComponent(
+                        viewer,
+                        "gui.pending_list.item.received_line",
+                        mapOf("datetime" to formatDateTime(plugin, viewer, createdAt))
+                    ),
                 )
             )
-        )
-        lore += lang.getComponent(
-            viewer,
-            "gui.pending_list.item.received_line",
-            mapOf("datetime" to formatDateTime(plugin, viewer, createdAt))
-        )
-        lore += lang.getComponent(viewer, "gui.common.separator")
-        lore += lang.getComponent(
-            viewer,
-            actionLineKey(plugin, viewer, actionMode),
-            mapOf("type" to typeLabel(plugin, viewer, type))
-        )
-        lore += lang.getComponent(viewer, "gui.common.separator")
+            .componentBlock(
+                listOf(
+                    lang.getComponent(
+                        viewer,
+                        actionLineKey(plugin, viewer, actionMode),
+                        mapOf("type" to typeLabel(plugin, viewer, type))
+                    )
+                )
+            )
+            .build()
         meta.lore(lore)
         meta.setEnchantmentGlintOverride(true)
 

--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/PlayerWorldGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/PlayerWorldGui.kt
@@ -10,6 +10,7 @@ import java.util.UUID
 import me.awabi2048.myworldmanager.MyWorldManager
 import me.awabi2048.myworldmanager.model.PlayerStats
 import me.awabi2048.myworldmanager.model.WorldData
+import me.awabi2048.myworldmanager.util.GuiItemFactory
 import me.awabi2048.myworldmanager.util.ItemTag
 import me.awabi2048.myworldmanager.util.PermissionManager
 import net.kyori.adventure.text.Component
@@ -432,13 +433,7 @@ class PlayerWorldGui(private val plugin: MyWorldManager) {
         }
 
         private fun createDecorationItem(material: Material): ItemStack {
-                val item = ItemStack(material)
-                val meta = item.itemMeta ?: return item
-                meta.displayName(Component.empty())
-                meta.isHideTooltip = true
-                item.itemMeta = meta
-                ItemTag.tagItem(item, ItemTag.TYPE_GUI_DECORATION)
-                return item
+                return GuiItemFactory.decoration(material)
         }
 
         private fun dateFormatterFor(player: Player): DateTimeFormatter {

--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/PortalGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/PortalGui.kt
@@ -2,12 +2,11 @@ package me.awabi2048.myworldmanager.gui
 
 import me.awabi2048.myworldmanager.MyWorldManager
 import me.awabi2048.myworldmanager.model.PortalData
+import me.awabi2048.myworldmanager.util.GuiItemFactory
 import me.awabi2048.myworldmanager.util.PortalItemUtil
 import me.awabi2048.myworldmanager.util.ItemTag
 import me.awabi2048.myworldmanager.util.WorldGateItemUtil
 import net.kyori.adventure.text.Component
-import net.kyori.adventure.text.format.TextDecoration
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
 import org.bukkit.Bukkit
 import org.bukkit.Color
@@ -46,8 +45,8 @@ class PortalGui(private val plugin: MyWorldManager) : Listener {
         
         val inventory = Bukkit.createInventory(null, 27, titleComponent)
 
-        val blackPane = createDecorationItem(Material.BLACK_STAINED_GLASS_PANE)
-        val greyPane = createDecorationItem(Material.GRAY_STAINED_GLASS_PANE)
+        val blackPane = GuiItemFactory.decoration(Material.BLACK_STAINED_GLASS_PANE)
+        val greyPane = GuiItemFactory.decoration(Material.GRAY_STAINED_GLASS_PANE)
 
         for (i in 0..8) inventory.setItem(i, blackPane)
         for (i in 18..26) inventory.setItem(i, blackPane)
@@ -207,25 +206,7 @@ class PortalGui(private val plugin: MyWorldManager) : Listener {
     }
 
     private fun createItem(material: Material, name: String, lore: List<Component>, type: String): ItemStack {
-        val item = ItemStack(material)
-        val meta = item.itemMeta ?: return item
-        
-        meta.displayName(LegacyComponentSerializer.legacySection().deserialize(name).decoration(TextDecoration.ITALIC, false))
-        meta.lore(lore)
-        
-        item.itemMeta = meta
-        ItemTag.tagItem(item, type)
-        return item
-    }
-
-    private fun createDecorationItem(material: Material): ItemStack {
-        val item = ItemStack(material)
-        val meta = item.itemMeta ?: return item
-        meta.displayName(Component.empty())
-        meta.isHideTooltip = true
-        item.itemMeta = meta
-        ItemTag.tagItem(item, ItemTag.TYPE_GUI_DECORATION)
-        return item
+        return GuiItemFactory.item(material, name, lore, type)
     }
 
     private fun getWoolColor(color: Color): Material {

--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/TemplateWizardGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/TemplateWizardGui.kt
@@ -4,9 +4,9 @@ import me.awabi2048.myworldmanager.MyWorldManager
 import me.awabi2048.myworldmanager.model.*
 import me.awabi2048.myworldmanager.repository.*
 import me.awabi2048.myworldmanager.util.CustomItem
+import me.awabi2048.myworldmanager.util.GuiItemFactory
 import me.awabi2048.myworldmanager.util.ItemTag
 import net.kyori.adventure.text.Component
-import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.TextDecoration
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
 import org.bukkit.Bukkit
@@ -46,8 +46,8 @@ class TemplateWizardGui(private val plugin: MyWorldManager) {
 
         // 装飾用
         // 装飾用
-        val blackPane = createDecorationItem(Material.BLACK_STAINED_GLASS_PANE)
-        val grayPane = createDecorationItem(Material.GRAY_STAINED_GLASS_PANE)
+        val blackPane = GuiItemFactory.decoration(Material.BLACK_STAINED_GLASS_PANE)
+        val grayPane = GuiItemFactory.decoration(Material.GRAY_STAINED_GLASS_PANE)
         
         for (i in 0..53) {
             if (i < 9 || i >= 45) {
@@ -131,23 +131,7 @@ class TemplateWizardGui(private val plugin: MyWorldManager) {
     }
 
     private fun createSettingItem(material: Material, display: String, lore: List<Component>, id: String): ItemStack {
-        val item = ItemStack(material)
-        val meta = item.itemMeta ?: return item
-        meta.displayName(LegacyComponentSerializer.legacySection().deserialize(display).decoration(TextDecoration.ITALIC, false))
-        meta.lore(lore)
-        item.itemMeta = meta
-        ItemTag.tagItem(item, id)
-        return item
-    }
-
-    private fun createDecorationItem(material: Material): ItemStack {
-        val item = ItemStack(material)
-        val meta = item.itemMeta ?: return item
-        meta.displayName(Component.empty())
-        meta.isHideTooltip = true
-        item.itemMeta = meta
-        ItemTag.tagItem(item, ItemTag.TYPE_GUI_DECORATION)
-        return item
+        return GuiItemFactory.item(material, display, lore, id)
     }
 
     fun getSession(uuid: UUID) = sessions[uuid]

--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/UserSettingsGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/UserSettingsGui.kt
@@ -3,10 +3,8 @@ package me.awabi2048.myworldmanager.gui
 import me.awabi2048.myworldmanager.MyWorldManager
 import me.awabi2048.myworldmanager.model.*
 import me.awabi2048.myworldmanager.repository.*
+import me.awabi2048.myworldmanager.util.GuiItemFactory
 import me.awabi2048.myworldmanager.util.ItemTag
-import net.kyori.adventure.text.Component
-import net.kyori.adventure.text.format.TextDecoration
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
 import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.entity.Player
@@ -90,8 +88,8 @@ class UserSettingsGui(private val plugin: MyWorldManager) {
         holder.inv = inventory
 
         // Fill Background
-        val blackPane = createDecorationItem(Material.BLACK_STAINED_GLASS_PANE)
-        val grayPane = createDecorationItem(Material.GRAY_STAINED_GLASS_PANE)
+        val blackPane = GuiItemFactory.decoration(Material.BLACK_STAINED_GLASS_PANE)
+        val grayPane = GuiItemFactory.decoration(Material.GRAY_STAINED_GLASS_PANE)
         
         // Top and Bottom Rows (Black)
         for (i in 0 until 9) inventory.setItem(i, blackPane)
@@ -123,25 +121,7 @@ class UserSettingsGui(private val plugin: MyWorldManager) {
     }
 
     private fun createItem(material: Material, name: String, loreLines: List<String>, tag: String): ItemStack {
-        val item = ItemStack(material)
-        val meta = item.itemMeta ?: return item
-        
-        meta.displayName(LegacyComponentSerializer.legacySection().deserialize(name).decoration(TextDecoration.ITALIC, false))
-        meta.lore(loreLines.map { LegacyComponentSerializer.legacySection().deserialize(it).decoration(TextDecoration.ITALIC, false) })
-        
-        item.itemMeta = meta
-        ItemTag.tagItem(item, tag)
-        return item
-    }
-
-    private fun createDecorationItem(material: Material): ItemStack {
-        val item = ItemStack(material)
-        val meta = item.itemMeta ?: return item
-        meta.displayName(Component.empty())
-        meta.isHideTooltip = true
-        item.itemMeta = meta
-        ItemTag.tagItem(item, ItemTag.TYPE_GUI_DECORATION)
-        return item
+        return GuiItemFactory.textItem(material, name, loreLines, tag)
     }
 
     class UserSettingsGuiHolder : org.bukkit.inventory.InventoryHolder {

--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/VisitGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/VisitGui.kt
@@ -3,8 +3,8 @@ package me.awabi2048.myworldmanager.gui
 import me.awabi2048.myworldmanager.MyWorldManager
 import me.awabi2048.myworldmanager.model.PublishLevel
 import me.awabi2048.myworldmanager.model.WorldData
+import me.awabi2048.myworldmanager.util.GuiItemFactory
 import me.awabi2048.myworldmanager.util.ItemTag
-import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.TextDecoration
 import org.bukkit.Bukkit
@@ -75,9 +75,10 @@ class VisitGui(private val plugin: MyWorldManager) {
                 val inventory = Bukkit.createInventory(holder, rowCount * 9, titleComp)
                 holder.inv = inventory
 
-                val blackPane =
-                        createDecorationItem(Material.BLACK_STAINED_GLASS_PANE, returnToWorld)
-                val greyPane = createDecorationItem(Material.GRAY_STAINED_GLASS_PANE, returnToWorld)
+                val blackPane = GuiItemFactory.decoration(Material.BLACK_STAINED_GLASS_PANE)
+                if (returnToWorld != null) ItemTag.setWorldUuid(blackPane, returnToWorld.uuid)
+                val greyPane = GuiItemFactory.decoration(Material.GRAY_STAINED_GLASS_PANE)
+                if (returnToWorld != null) ItemTag.setWorldUuid(greyPane, returnToWorld.uuid)
 
                 for (i in 0..8) inventory.setItem(i, blackPane)
                 for (i in (rowCount - 1) * 9 until rowCount * 9) inventory.setItem(i, blackPane)
@@ -197,31 +198,15 @@ class VisitGui(private val plugin: MyWorldManager) {
 
         private fun createBackButton(player: Player, returnToWorld: WorldData): ItemStack {
                 val lang = plugin.languageManager
-                val item = ItemStack(Material.REDSTONE)
-                val meta = item.itemMeta ?: return item
-                meta.displayName(
+                val item = GuiItemFactory.item(
+                        Material.REDSTONE,
                         lang.getComponent(player, "gui.common.return")
                                 .color(NamedTextColor.YELLOW)
-                                .decorate(TextDecoration.BOLD)
+                                .decorate(TextDecoration.BOLD),
+                        listOf(lang.getComponent(player, "gui.common.return_desc")),
+                        ItemTag.TYPE_GUI_RETURN
                 )
-                meta.lore(listOf(lang.getComponent(player, "gui.common.return_desc")))
-                item.itemMeta = meta
-                ItemTag.tagItem(item, ItemTag.TYPE_GUI_RETURN)
                 ItemTag.setWorldUuid(item, returnToWorld.uuid)
-                return item
-        }
-
-        private fun createDecorationItem(
-                material: Material,
-                returnToWorld: WorldData? = null
-        ): ItemStack {
-                val item = ItemStack(material)
-                val meta = item.itemMeta ?: return item
-                meta.displayName(Component.empty())
-                meta.isHideTooltip = true
-                item.itemMeta = meta
-                ItemTag.tagItem(item, ItemTag.TYPE_GUI_DECORATION)
-                if (returnToWorld != null) ItemTag.setWorldUuid(item, returnToWorld.uuid)
                 return item
         }
 

--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/VisitWorldGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/VisitWorldGui.kt
@@ -4,9 +4,9 @@ import me.awabi2048.myworldmanager.MyWorldManager
 import me.awabi2048.myworldmanager.model.PublishLevel
 import me.awabi2048.myworldmanager.model.WorldData
 import me.awabi2048.myworldmanager.util.GuiHelper
+import me.awabi2048.myworldmanager.util.GuiItemFactory
 import me.awabi2048.myworldmanager.util.ItemTag
 import me.awabi2048.myworldmanager.util.PlayerNameUtil
-import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.TextDecoration
 import org.bukkit.Bukkit
 import org.bukkit.Material
@@ -98,9 +98,9 @@ class VisitWorldGui(private val plugin: MyWorldManager) {
     }
 
     private fun fillBaseLayout(inventory: Inventory) {
-        val blackPane = createDecorationItem(Material.BLACK_STAINED_GLASS_PANE)
-        val grayPane = createDecorationItem(Material.GRAY_STAINED_GLASS_PANE)
-        val whitePane = createDecorationItem(Material.WHITE_STAINED_GLASS_PANE)
+        val blackPane = GuiItemFactory.decoration(Material.BLACK_STAINED_GLASS_PANE)
+        val grayPane = GuiItemFactory.decoration(Material.GRAY_STAINED_GLASS_PANE)
+        val whitePane = GuiItemFactory.decoration(Material.WHITE_STAINED_GLASS_PANE)
 
         for (i in 0..8) inventory.setItem(i, blackPane)
         for (i in 45..53) inventory.setItem(i, blackPane)
@@ -251,16 +251,6 @@ class VisitWorldGui(private val plugin: MyWorldManager) {
         item.itemMeta = meta
         ItemTag.tagItem(item, ItemTag.TYPE_GUI_WORLD_ITEM)
         ItemTag.setWorldUuid(item, world.uuid)
-        return item
-    }
-
-    private fun createDecorationItem(material: Material): ItemStack {
-        val item = ItemStack(material)
-        val meta = item.itemMeta ?: return item
-        meta.displayName(Component.empty())
-        meta.isHideTooltip = true
-        item.itemMeta = meta
-        ItemTag.tagItem(item, ItemTag.TYPE_GUI_DECORATION)
         return item
     }
 

--- a/src/main/kotlin/me/awabi2048/myworldmanager/gui/WorldSettingsGui.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/gui/WorldSettingsGui.kt
@@ -12,6 +12,8 @@ import me.awabi2048.myworldmanager.model.PublishLevel
 import me.awabi2048.myworldmanager.model.WorldData
 import me.awabi2048.myworldmanager.session.SettingsAction
 import me.awabi2048.myworldmanager.util.GuiHelper.scheduleGuiTransitionReset
+import me.awabi2048.myworldmanager.util.GuiItemFactory
+import me.awabi2048.myworldmanager.util.GuiLoreBuilder
 import me.awabi2048.myworldmanager.util.ItemTag
 import me.awabi2048.myworldmanager.util.PermissionManager
 import net.kyori.adventure.text.Component
@@ -2222,29 +2224,7 @@ class WorldSettingsGui(private val plugin: MyWorldManager) {
                 loreLines: List<String>,
                 tag: String
         ): ItemStack {
-                val item = ItemStack(material)
-                val meta = item.itemMeta ?: return item
-
-                // 装飾を指定しない (LegacyComponentSerializerにおまかせする)
-                meta.displayName(
-                        LegacyComponentSerializer.legacySection()
-                                .deserialize(name)
-                                .decoration(TextDecoration.ITALIC, false)
-                )
-
-                val loreComponents =
-                        loreLines.map {
-                                LegacyComponentSerializer.legacySection()
-                                        .deserialize(it)
-                                        .decoration(TextDecoration.ITALIC, false)
-                        }
-                meta.lore(loreComponents)
-
-                item.itemMeta = meta
-                ItemTag.tagItem(item, tag)
-                item.itemMeta = meta
-                ItemTag.tagItem(item, tag)
-                return item
+                return GuiItemFactory.textItem(material, name, loreLines, tag)
         }
 
         private data class BorderInfo(
@@ -2294,20 +2274,7 @@ class WorldSettingsGui(private val plugin: MyWorldManager) {
                 loreComponents: List<Component>,
                 tag: String
         ): ItemStack {
-                val item = ItemStack(material)
-                val meta = item.itemMeta ?: return item
-
-                meta.displayName(
-                        LegacyComponentSerializer.legacySection()
-                                .deserialize(name)
-                                .decoration(TextDecoration.ITALIC, false)
-                )
-
-                meta.lore(loreComponents.map { it.decoration(TextDecoration.ITALIC, false) })
-
-                item.itemMeta = meta
-                ItemTag.tagItem(item, tag)
-                return item
+                return GuiItemFactory.item(material, name, loreComponents, tag)
         }
 
         fun openTagEditor(player: Player, worldData: WorldData) {
@@ -2960,12 +2927,6 @@ class WorldSettingsGui(private val plugin: MyWorldManager) {
         }
 
         private fun createDecorationItem(material: Material): ItemStack {
-                val item = ItemStack(material)
-                val meta = item.itemMeta ?: return item
-                meta.displayName(Component.empty())
-                meta.isHideTooltip = true
-                item.itemMeta = meta
-                ItemTag.tagItem(item, ItemTag.TYPE_GUI_DECORATION)
-                return item
+                return GuiItemFactory.decoration(material)
         }
 }

--- a/src/main/kotlin/me/awabi2048/myworldmanager/listener/PortalListener.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/listener/PortalListener.kt
@@ -236,7 +236,7 @@ class PortalListener(private val plugin: MyWorldManager) : Listener {
 
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     fun onAnyRightClickForPortalMenu(event: PlayerInteractEvent) {
         if (event.action != Action.RIGHT_CLICK_BLOCK) return
 
@@ -259,7 +259,7 @@ class PortalListener(private val plugin: MyWorldManager) : Listener {
         PortalGui(plugin).open(player, portal)
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     fun onAnyRightClickForGateMenu(event: PlayerInteractEvent) {
         if (event.action != Action.RIGHT_CLICK_BLOCK) return
 
@@ -682,6 +682,15 @@ class PortalListener(private val plugin: MyWorldManager) : Listener {
             return
         }
         if (!ItemTag.isType(item, ItemTag.TYPE_PORTAL)) return
+
+        val existingPortal = plugin.portalRepository.findByContainingLocation(event.block.location)
+        if (existingPortal?.isGate() == true) {
+            event.isCancelled = true
+            event.player.sendMessage(
+                plugin.languageManager.getMessage(event.player, "error.portal_place_in_world_gate")
+            )
+            return
+        }
         
         val lang = plugin.languageManager
         val worldUuid = PortalItemUtil.getBoundWorldUuid(item)

--- a/src/main/kotlin/me/awabi2048/myworldmanager/listener/PortalListener.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/listener/PortalListener.kt
@@ -237,6 +237,29 @@ class PortalListener(private val plugin: MyWorldManager) : Listener {
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
+    fun onAnyRightClickForPortalMenu(event: PlayerInteractEvent) {
+        if (event.action != Action.RIGHT_CLICK_BLOCK) return
+
+        val player = event.player
+        if (player.isSneaking) return
+        if (event.hand != EquipmentSlot.HAND) return
+
+        val clickedBlock = event.clickedBlock ?: return
+        val handItem = player.inventory.itemInMainHand
+
+        if (ItemTag.isType(handItem, ItemTag.TYPE_WORLD_GATE) || ItemTag.isType(handItem, ItemTag.TYPE_PORTAL)) {
+            return
+        }
+
+        val portal = plugin.portalRepository.findByLocation(clickedBlock.location) ?: return
+        if (portal.isGate()) return
+        if (!canOpenPortalMenu(player, portal)) return
+
+        event.isCancelled = true
+        PortalGui(plugin).open(player, portal)
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
     fun onAnyRightClickForGateMenu(event: PlayerInteractEvent) {
         if (event.action != Action.RIGHT_CLICK_BLOCK) return
 
@@ -251,12 +274,16 @@ class PortalListener(private val plugin: MyWorldManager) : Listener {
             return
         }
 
-        val portal = plugin.portalRepository.findByContainingLocation(clickedBlock.location)
-        if (portal != null && (portal.ownerUuid == player.uniqueId || player.hasPermission("myworldmanager.admin"))) {
-            if (!portal.isGate()) return
-            event.isCancelled = true
-            PortalGui(plugin).open(player, portal)
-        }
+        val portal = plugin.portalRepository.findByContainingLocation(clickedBlock.location) ?: return
+        if (!portal.isGate()) return
+        if (!canOpenPortalMenu(player, portal)) return
+
+        event.isCancelled = true
+        PortalGui(plugin).open(player, portal)
+    }
+
+    private fun canOpenPortalMenu(player: org.bukkit.entity.Player, portal: PortalData): Boolean {
+        return portal.ownerUuid == player.uniqueId || player.hasPermission("myworldmanager.admin")
     }
 
     private fun showWorldGateConfirm(player: org.bukkit.entity.Player) {

--- a/src/main/kotlin/me/awabi2048/myworldmanager/util/GuiItemFactory.kt
+++ b/src/main/kotlin/me/awabi2048/myworldmanager/util/GuiItemFactory.kt
@@ -1,0 +1,189 @@
+package me.awabi2048.myworldmanager.util
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.TextDecoration
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
+import org.bukkit.Material
+import org.bukkit.OfflinePlayer
+import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.SkullMeta
+
+private val guiLegacySerializer = LegacyComponentSerializer.legacySection()
+
+data class GuiLoreAction(val operation: String? = null, val action: String)
+
+private data class GuiLoreSection(
+    val lines: List<Component>,
+    val showClosingSeparator: Boolean = true,
+)
+
+class GuiLoreBuilder(
+    private val languageManager: LanguageManager,
+    private val player: Player,
+) {
+    private val sections = mutableListOf<GuiLoreSection>()
+
+    private fun addSection(lines: List<Component>, showClosingSeparator: Boolean = true) {
+        val normalized = lines.filter { it != Component.empty() }
+        if (normalized.isNotEmpty()) {
+            sections += GuiLoreSection(normalized, showClosingSeparator)
+        }
+    }
+
+    fun line(line: String): GuiLoreBuilder {
+        val normalized = line.trim()
+        if (normalized.isNotEmpty()) {
+            addSection(listOf(legacy(normalized)))
+        }
+        return this
+    }
+
+    fun block(lines: List<String>): GuiLoreBuilder {
+        val normalized = lines
+            .flatMap { it.split('\n') }
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .map { raw -> if (raw.startsWith("§")) legacy(raw) else legacy("§7$raw") }
+        addSection(normalized)
+        return this
+    }
+
+    fun componentBlock(lines: List<Component>): GuiLoreBuilder {
+        addSection(lines.map { it.decoration(TextDecoration.ITALIC, false) })
+        return this
+    }
+
+    fun data(name: String, value: String): GuiLoreBuilder {
+        return data(listOf(name to value))
+    }
+
+    fun data(entries: List<Pair<String, String>>): GuiLoreBuilder {
+        if (entries.isNotEmpty()) {
+            addSection(entries.map { (name, value) -> legacy("§f§l| §7$name $value") })
+        }
+        return this
+    }
+
+    fun singleAction(action: String): GuiLoreBuilder {
+        return rawAction("§e§n$action", false)
+    }
+
+    fun multiActions(actions: List<GuiLoreAction>): GuiLoreBuilder {
+        if (actions.isNotEmpty()) {
+            addSection(actions.map { legacy("§e§l| §e${it.operation ?: ""} §7${it.action}".trim()) })
+        }
+        return this
+    }
+
+    fun action(action: String): GuiLoreBuilder {
+        return rawAction(action, false)
+    }
+
+    fun rawAction(text: String, showClosingSeparator: Boolean = false): GuiLoreBuilder {
+        val normalized = text.trim()
+        if (normalized.isNotEmpty()) {
+            addSection(listOf(legacy(normalized)), showClosingSeparator)
+        }
+        return this
+    }
+
+    fun warning(text: String): GuiLoreBuilder {
+        val normalized = text.trim()
+        if (normalized.isNotEmpty()) {
+            addSection(listOf(legacy(if (normalized.startsWith("§")) normalized else "§c§n※ $normalized")))
+        }
+        return this
+    }
+
+    fun separator(): Component {
+        return languageManager.getComponent(player, "gui.common.separator")
+            .decoration(TextDecoration.ITALIC, false)
+    }
+
+    fun build(): List<Component> {
+        if (sections.isEmpty()) {
+            return emptyList()
+        }
+
+        val separator = separator()
+        val lore = buildList {
+            sections.forEach { section ->
+                add(separator)
+                addAll(section.lines)
+            }
+            if (sections.last().showClosingSeparator) {
+                add(separator)
+            }
+        }
+        return GuiHelper.cleanupLore(lore, separator)
+    }
+}
+
+object GuiItemFactory {
+    fun decoration(material: Material, tag: String = ItemTag.TYPE_GUI_DECORATION): ItemStack {
+        val item = ItemStack(material)
+        val meta = item.itemMeta ?: return item
+        meta.displayName(Component.empty())
+        meta.isHideTooltip = true
+        item.itemMeta = meta
+        ItemTag.tagItem(item, tag)
+        return item
+    }
+
+    fun textItem(material: Material, name: String, loreLines: List<String>, tag: String? = null): ItemStack {
+        return item(material, legacy(name), loreLines.map { legacy(it) }, tag)
+    }
+
+    fun item(material: Material, name: String, loreComponents: List<Component>, tag: String? = null): ItemStack {
+        return item(material, legacy(name), loreComponents, tag)
+    }
+
+    fun item(material: Material, name: Component, loreComponents: List<Component>, tag: String? = null): ItemStack {
+        val item = ItemStack(material)
+        val meta = item.itemMeta ?: return item
+        meta.displayName(name.decoration(TextDecoration.ITALIC, false))
+        meta.lore(loreComponents.map { it.decoration(TextDecoration.ITALIC, false) })
+        item.itemMeta = meta
+        if (tag != null) {
+            ItemTag.tagItem(item, tag)
+        }
+        return item
+    }
+
+    fun playerHead(owner: OfflinePlayer, name: String, loreComponents: List<Component>, tag: String? = null): ItemStack {
+        val item = ItemStack(Material.PLAYER_HEAD)
+        val meta = item.itemMeta as? SkullMeta ?: return item
+        meta.owningPlayer = owner
+        meta.displayName(legacy(name))
+        meta.lore(loreComponents.map { it.decoration(TextDecoration.ITALIC, false) })
+        item.itemMeta = meta
+        if (tag != null) {
+            ItemTag.tagItem(item, tag)
+        }
+        return item
+    }
+
+    fun playerHead(owner: OfflinePlayer, name: Component, loreComponents: List<Component>, tag: String? = null): ItemStack {
+        val item = ItemStack(Material.PLAYER_HEAD)
+        val meta = item.itemMeta as? SkullMeta ?: return item
+        meta.owningPlayer = owner
+        meta.displayName(name.decoration(TextDecoration.ITALIC, false))
+        meta.lore(loreComponents.map { it.decoration(TextDecoration.ITALIC, false) })
+        item.itemMeta = meta
+        if (tag != null) {
+            ItemTag.tagItem(item, tag)
+        }
+        return item
+    }
+
+    fun legacy(raw: String): Component {
+        return guiLegacySerializer.deserialize(raw)
+            .decoration(TextDecoration.ITALIC, false)
+    }
+}
+
+private fun legacy(raw: String): Component {
+    return guiLegacySerializer.deserialize(raw)
+        .decoration(TextDecoration.ITALIC, false)
+}

--- a/src/main/resources/lang/en_us.yml
+++ b/src/main/resources/lang/en_us.yml
@@ -1830,6 +1830,7 @@ messages:
   portal_unbind_success: §ePortal binding removed.
   portal_place_success: §aWorld portal placed successfully.
   portal_broken: §eWorld portal has been broken.
+  error.portal_place_in_world_gate: §cYou cannot place a world portal inside a world gate.
   world_gate_bind_success: §aWorld gate bound to "{destination}".
   world_gate_unbind_success: §a World gate link has been removed.
   world_gate_select_first: §eRight-click a block to select point 1 for the world gate.

--- a/src/main/resources/lang/ja_jp.yml
+++ b/src/main/resources/lang/ja_jp.yml
@@ -1982,6 +1982,7 @@ messages:
   portal_unbind_success: "§eポータルの紐づけを解除しました"
   portal_place_success: "§aワールドポータルを設置しました"
   portal_broken: "§eワールドポータルが破壊されました"
+  error.portal_place_in_world_gate: "§cワールドゲートの内部にはワールドポータルを設置できません。"
   world_gate_bind_success: "§aこのワールドゲートを「{destination}」に紐づけました"
   world_gate_unbind_success: "§aワールドゲートのリンクを解除しました。"
   world_gate_select_first: "§eワールドゲートの1点目を右クリックで選択してください。"


### PR DESCRIPTION
## 概要
- 通常のワールドポータルとワールドゲートの右クリック開封を分離し、どちらも同じ管理UIを開けるようにしました。
- キャンセル済みの右クリックではGUIを開かないようにし、ワールドゲート内部にはワールドポータルを設置できないようにしました。
- 既存GUI整理の変更も取り込みました。

## 確認
- `mvn clean package` 成功
- ビルド成果物を `D:\Minecraft\Chiyogami 1.21.8\plugins\MyWorldManager-v1.4.0.jar` にコピー済み